### PR TITLE
Correctly fail unsuccessful `just test` invocations in CI

### DIFF
--- a/app/justfile
+++ b/app/justfile
@@ -61,7 +61,15 @@ status-prod queue="public1":
 
 test:
     #!/usr/bin/env bash
-    just down -v
+    set -e # exit when any command fails, preserving the status of the failed command
+
+    cleanup() {
+        just down -v
+    }
+
+    trap cleanup EXIT # cleanup when the script exits for any reason, including failure
+
+    cleanup
     # A local NPM registry saves time, bandwidth, and avoids rate limits
     STATUS_CODE=$(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:4873)
     if [ $STATUS_CODE = "200" ]; then
@@ -72,7 +80,6 @@ test:
     APP_PORT=4470 just test/test
     APP_PORT=4470 just shared/test
     APP_PORT=4470 just cli/test
-    just down -v
 
 # Clean up the project
 @test-cleanup:


### PR DESCRIPTION
As the commit message says, this adds proper failure to the `just test` job, and also invokes cleanup actions when exiting for any reasons (including said failure). This can be shown to work in the failing CI job for this branch itself: https://github.com/metapages/compute-queues/pull/new/ensure-correct-gha-failure