### PR TITLE
GCP Autoscaling Worker Deployment

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,8 @@
 /.cache
+
+# Terraform files
+.terraform*
+*.tfstate*
+
+# Terraform plan outputs
+*.out

--- a/app/deploy/gcp/README.md
+++ b/app/deploy/gcp/README.md
@@ -21,11 +21,84 @@ This module deploys metapage workers as one or more [Managed Instance Groups](ht
 
 Since the metrics to determine scaling are served from the workers themselves, and we can't always be sure of any particular worker being online to request metrics from, we place an [Internal Load Balancer](https://cloud.google.com/load-balancing/docs/l7-internal) in front of the MIGs. We then use a separate instance for metric collection, which runs an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) to continually scrape metrics from the workers and export them to [Google Cloud Monitoring](https://cloud.google.com/monitoring/custom-metrics).
 
+The module supports the creation of worker groups [with GPUs](https://cloud.google.com/compute/docs/gpus), by providing a definition with *either* N1-series instances and a populated `gpus` block, or accelerator-optimized instances with no `gpus` block included.
+
 ## Gotchas
 
-There are currently a few quirks to be aware of when operating this infrastructure.
+There are some quirks and things to be careful about when operating this module.
 
 - Both the workers and the metrics collector run containers defined using [GCE instance metadata](https://cloud.google.com/compute/docs/containers/deploying-containers). Updating the container image/VM metadata will not automatically result in applied changes to the running VM, so you may need to have the MIG restart/recreate instances to fully apply changes right now.
 - When the queue is getting a lot of jobs added & removed, different MIG members may report different metrics for `queue_length`, and can continue reporting that there are unfinished jobs in the queue even after the queue is empty for a little while -- however, this will gradually fall off and the MIG *will* eventually scale in, so don't be concerned if it looks "stuck" at a higher than necessary scale for a couple minutes. MIG autoscaling is by default rather conservative to prevent thrashing and yo-yoing of instances.
 - There are a number of failure points in the process required to autoscale the MIGs for our case, and those failures can happen silently. Ideally we build a dashboard in Cloud Monitoring to get a view of our system at a glance, but this doesn't include one yet. Places to check for failures include: 1) the /metrics endpoints on the MIG instance containers, 2) connectivity to request metrics from MIG instances from the metrics collector (especially load balancer, DNS, etc configuration), and 3) the metrics collector itself which processes and exports to Cloud Monitoring.
 - This module enables a number of Google APIs, and does *not* disable them or destroy the project when `terraform destroy` is run. If you want to be sure everything is torn down, you should delete your project manually in the GCP console.
+- The worker groups in this module don't yet scale to zero, so be careful about running expensive instance types -- especially if scaling limits are high! If there's any condition that causes the worker group to remain scaled out, you could be in for a nice surprise bill from GCP.
+
+# Terraform Module
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.9.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.7.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.10 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 6.7.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 6.10.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_metrics_container"></a> [metrics\_container](#module\_metrics\_container) | terraform-google-modules/container-vm/google | ~> 3.2 |
+| <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | ~> 12.1.0 |
+| <a name="module_mig_template"></a> [mig\_template](#module\_mig\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 12.1.0 |
+| <a name="module_worker_vm"></a> [worker\_vm](#module\_worker\_vm) | terraform-google-modules/container-vm/google | ~> 3.2 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_compute_region_autoscaler.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_region_autoscaler) | resource |
+| [google_compute_firewall.ilb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.ilb_health_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_forwarding_rule.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
+| [google_compute_instance.metrics](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
+| [google_compute_region_backend_service.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_backend_service) | resource |
+| [google_compute_region_health_check.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_health_check) | resource |
+| [google_compute_region_target_http_proxy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_target_http_proxy) | resource |
+| [google_compute_region_url_map.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_url_map) | resource |
+| [google_compute_router.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
+| [google_compute_router_nat.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
+| [google_compute_subnetwork.ilb_proxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
+| [google_dns_managed_zone.workers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
+| [google_dns_record_set.workers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_project_service.cloud_logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.cloud_monitoring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.cloud_run](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.cloud_trace](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.compute](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.dns](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_project_service.iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.mig_template_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_compute_network.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
+| [google_compute_subnetwork.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_opentelemetry_collector_image"></a> [opentelemetry\_collector\_image](#input\_opentelemetry\_collector\_image) | Address of the container image to use for the OpenTelemetry Collector | `string` | n/a | yes |
+| <a name="input_queue_id"></a> [queue\_id](#input\_queue\_id) | The queue id for the worker | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region in which we're rolling out IaC | `string` | n/a | yes |
+| <a name="input_worker_groups"></a> [worker\_groups](#input\_worker\_groups) | Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc. The 'gpus' block is only appropriate for N1 series VMs with attached GPUs. If any other instance type is specified (like accelerator-optimized VMs), the 'gpus' block will be ignored.) | <pre>map(object({<br/>    queue_id      = string<br/>    instance_type = string<br/>    cpus          = number<br/>    gpus = optional(object({<br/>      count = number<br/>      type  = string<br/>    }))<br/>  }))</pre> | n/a | yes |
+| <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Address of the container image to use for the worker | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/app/deploy/gcp/README.md
+++ b/app/deploy/gcp/README.md
@@ -1,9 +1,31 @@
 # Compute providers
 
+**WIP**: This is a work in progress and still needs some cleanup before it's production-ready. It is usable though.
+
 https://www.notion.so/metapages/Metapage-compute-worker-providers-0913a04cd3784c569dfa374bc91e0bea?pvs=4
 
 Infrastructure code for cloud providers to create horizontally scaling workers.
 
-## Managing VMs
+## Basic Usage
 
-The VM image used in this infra is manually created and updated right now. A future improvement would be to automate/make a factory for this process using Packer and Cloud Build.
+This worker infrastructure uses [terraform](https://www.terraform.io/) to create resources in GCP. You need a GCP project and administrative privileges within that project to create the resources defined here. Google provides [documentation](https://cloud.google.com/docs/terraform/authentication) on how to authenticate terraform with GCP, which you'll need to follow before executing the below.
+
+1. `terraform init` to initialize the module and its dependencies
+2. `terraform plan -out plan.out` to generate a plan of the exact changes that will be performed (the plan name is arbitrary)
+3. `terraform apply plan.out` to apply the plan
+4. `terraform destroy` to tear down the infrastructure
+
+## Design
+
+This module deploys metapage workers as one or more [Managed Instance Groups](https://cloud.google.com/compute/docs/instance-groups) (MIGs) in GCP. The MIGs which should be created are defined via the `worker_groups` variable. Each MIG is assigned a job queue ID as part of its definition, and autoscales based on the `queue_length` Prometheus-style metric its own workers expose at the `/metrics` endpoint. This means as more jobs are added to the job queue, the MIG will automatically scale up to handle the increased load. As the number of unfinished jobs decreases, the MIG will conservatively scale in to save costs.
+
+Since the metrics to determine scaling are served from the workers themselves, and we can't always be sure of any particular worker being online to request metrics from, we place an [Internal Load Balancer](https://cloud.google.com/load-balancing/docs/l7-internal) in front of the MIGs. We then use a separate instance for metric collection, which runs an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) to continually scrape metrics from the workers and export them to [Google Cloud Monitoring](https://cloud.google.com/monitoring/custom-metrics).
+
+## Gotchas
+
+There are currently a few quirks to be aware of when operating this infrastructure.
+
+- Both the workers and the metrics collector run containers defined using [GCE instance metadata](https://cloud.google.com/compute/docs/containers/deploying-containers). Updating the container image/VM metadata will not automatically result in applied changes to the running VM, so you may need to have the MIG restart/recreate instances to fully apply changes right now.
+- When the queue is getting a lot of jobs added & removed, different MIG members may report different metrics for `queue_length`, and can continue reporting that there are unfinished jobs in the queue even after the queue is empty for a little while -- however, this will gradually fall off and the MIG *will* eventually scale in, so don't be concerned if it looks "stuck" at a higher than necessary scale for a couple minutes. MIG autoscaling is by default rather conservative to prevent thrashing and yo-yoing of instances.
+- There are a number of failure points in the process required to autoscale the MIGs for our case, and those failures can happen silently. Ideally we build a dashboard in Cloud Monitoring to get a view of our system at a glance, but this doesn't include one yet. Places to check for failures include: 1) the /metrics endpoints on the MIG instance containers, 2) connectivity to request metrics from MIG instances from the metrics collector (especially load balancer, DNS, etc configuration), and 3) the metrics collector itself which processes and exports to Cloud Monitoring.
+- This module enables a number of Google APIs, and does *not* disable them or destroy the project when `terraform destroy` is run. If you want to be sure everything is torn down, you should delete your project manually in the GCP console.

--- a/app/deploy/gcp/README.md
+++ b/app/deploy/gcp/README.md
@@ -1,0 +1,9 @@
+# Compute providers
+
+https://www.notion.so/metapages/Metapage-compute-worker-providers-0913a04cd3784c569dfa374bc91e0bea?pvs=4
+
+Infrastructure code for cloud providers to create horizontally scaling workers.
+
+## Managing VMs
+
+The VM image used in this infra is manually created and updated right now. A future improvement would be to automate/make a factory for this process using Packer and Cloud Build.

--- a/app/deploy/gcp/README.md
+++ b/app/deploy/gcp/README.md
@@ -11,6 +11,8 @@ This worker infrastructure uses [terraform](https://www.terraform.io/) to create
 3. `terraform apply plan.out` to apply the plan
 4. `terraform destroy` to tear down the infrastructure
 
+**NOTE**: If you intend to deploy workers with GPUs, you'll need to make sure your project has GPU quota available for the kind of GPUS you're requesting in the region you're deploying to. `GPUS-ALL-REGIONS-per-project` is often set to `0` by default, so you may need to request a quota increase on that in order to use GPUs at all. Beyond that, there may be specific quotas for the kind of GPU you're requesting which have to be raised.
+
 ## Design
 
 This module deploys metapage workers as one or more [Managed Instance Groups](https://cloud.google.com/compute/docs/instance-groups) (MIGs) in GCP. The MIGs which should be created are defined via the `worker_groups` variable. Each MIG is assigned a job queue ID as part of its definition, and autoscales based on the `queue_length` Prometheus-style metric its own workers expose at the `/metrics` endpoint. This means as more jobs are added to the job queue, the MIG will automatically scale up to handle the increased load. As the number of unfinished jobs decreases, the MIG will conservatively scale in to save costs.

--- a/app/deploy/gcp/README.md
+++ b/app/deploy/gcp/README.md
@@ -1,10 +1,6 @@
-# Compute providers
+# Compute Workers on GCP
 
-**WIP**: This is a work in progress and still needs some cleanup before it's production-ready. It is usable though.
-
-https://www.notion.so/metapages/Metapage-compute-worker-providers-0913a04cd3784c569dfa374bc91e0bea?pvs=4
-
-Infrastructure code for cloud providers to create horizontally scaling workers.
+Infrastructure code to create horizontally scaling Metapage worker deployments on Google Cloud Platform.
 
 ## Basic Usage
 
@@ -23,6 +19,8 @@ Since the metrics to determine scaling are served from the workers themselves, a
 
 The module supports the creation of worker groups [with GPUs](https://cloud.google.com/compute/docs/gpus), by providing a definition with *either* N1-series instances and a populated `gpus` block, or accelerator-optimized instances with no `gpus` block included.
 
+Workers are currently scaled under the assumption that 1 CPU core should handle 1 job off the queue, so a VM with 4 CPUs will pull 4 jobs off the queue before the autoscaler decides it needs more worker VMs.
+
 ## Gotchas
 
 There are some quirks and things to be careful about when operating this module.
@@ -32,6 +30,7 @@ There are some quirks and things to be careful about when operating this module.
 - There are a number of failure points in the process required to autoscale the MIGs for our case, and those failures can happen silently. Ideally we build a dashboard in Cloud Monitoring to get a view of our system at a glance, but this doesn't include one yet. Places to check for failures include: 1) the /metrics endpoints on the MIG instance containers, 2) connectivity to request metrics from MIG instances from the metrics collector (especially load balancer, DNS, etc configuration), and 3) the metrics collector itself which processes and exports to Cloud Monitoring.
 - This module enables a number of Google APIs, and does *not* disable them or destroy the project when `terraform destroy` is run. If you want to be sure everything is torn down, you should delete your project manually in the GCP console.
 - The worker groups in this module don't yet scale to zero, so be careful about running expensive instance types -- especially if scaling limits are high! If there's any condition that causes the worker group to remain scaled out, you could be in for a nice surprise bill from GCP.
+- Worker MIGs are currently zonal, meaning they're confined to a single zone in the deployed region. This leaves them more vulnerable to zonal outages.
 
 # Terraform Module
 

--- a/app/deploy/gcp/README.md
+++ b/app/deploy/gcp/README.md
@@ -15,9 +15,9 @@ This worker infrastructure uses [terraform](https://www.terraform.io/) to create
 
 ## Design
 
-This module deploys metapage workers as one or more [Managed Instance Groups](https://cloud.google.com/compute/docs/instance-groups) (MIGs) in GCP. The MIGs which should be created are defined via the `worker_groups` variable. Each MIG is assigned a job queue ID as part of its definition, and autoscales based on the `queue_length` Prometheus-style metric its own workers expose at the `/metrics` endpoint. This means as more jobs are added to the job queue, the MIG will automatically scale up to handle the increased load. As the number of unfinished jobs decreases, the MIG will conservatively scale in to save costs.
+This module deploys metapage workers as one or more [Managed Instance Groups](https://cloud.google.com/compute/docs/instance-groups) (MIGs) in GCP. The MIGs which should be created are defined via the `worker_groups` variable. Each MIG is assigned a job queue ID as part of its definition, and autoscales based on the `queue_length` Prometheus-style metric they pull from [Google Cloud Monitoring](https://cloud.google.com/monitoring/custom-metrics). This means as more jobs are added to the job queue, the MIG will automatically scale up to handle the increased load. As the number of unfinished jobs decreases, the MIG will conservatively scale in to save costs.
 
-Since the metrics to determine scaling are served from the workers themselves, and we can't always be sure of any particular worker being online to request metrics from, we place an [Internal Load Balancer](https://cloud.google.com/load-balancing/docs/l7-internal) in front of the MIGs. We then use a separate instance for metric collection, which runs an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) to continually scrape metrics from the workers and export them to [Google Cloud Monitoring](https://cloud.google.com/monitoring/custom-metrics).
+The scaling metrics are pushed into Google Cloud Monitoring via [OpenTelemetry collector](https://opentelemetry.io/docs/collector/), which runs in its own instance to continually scrape metapage.io metrics endpoints for the relevant queues.
 
 The module supports the creation of worker groups [with GPUs](https://cloud.google.com/compute/docs/gpus), by providing a definition with *either* N1-series instances and a populated `gpus` block, or accelerator-optimized instances with no `gpus` block included.
 
@@ -28,10 +28,8 @@ Workers are currently scaled under the assumption that 1 CPU core should handle 
 There are some quirks and things to be careful about when operating this module.
 
 - Both the workers and the metrics collector run containers defined using [GCE instance metadata](https://cloud.google.com/compute/docs/containers/deploying-containers). Updating the container image/VM metadata will not automatically result in applied changes to the running VM, so you may need to have the MIG restart/recreate instances to fully apply changes right now.
-- When the queue is getting a lot of jobs added & removed, different MIG members may report different metrics for `queue_length`, and can continue reporting that there are unfinished jobs in the queue even after the queue is empty for a little while -- however, this will gradually fall off and the MIG *will* eventually scale in, so don't be concerned if it looks "stuck" at a higher than necessary scale for a couple minutes. MIG autoscaling is by default rather conservative to prevent thrashing and yo-yoing of instances.
-- There are a number of failure points in the process required to autoscale the MIGs for our case, and those failures can happen silently. Ideally we build a dashboard in Cloud Monitoring to get a view of our system at a glance, but this doesn't include one yet. Places to check for failures include: 1) the /metrics endpoints on the MIG instance containers, 2) connectivity to request metrics from MIG instances from the metrics collector (especially load balancer, DNS, etc configuration), and 3) the metrics collector itself which processes and exports to Cloud Monitoring.
+- There are a couple points of failure in the process required to autoscale the MIGs for our case, and those failures can happen silently. Ideally we build a dashboard in Cloud Monitoring to get a view of our system at a glance, but this doesn't include one yet. The most obvious first place to check in case scaling isn't working is the metrics collector itself, which processes and exports metrics for scaling to Cloud Monitoring.
 - This module enables a number of Google APIs, and does *not* disable them or destroy the project when `terraform destroy` is run. If you want to be sure everything is torn down, you should delete your project manually in the GCP console.
-- The worker groups in this module don't yet scale to zero, so be careful about running expensive instance types -- especially if scaling limits are high! If there's any condition that causes the worker group to remain scaled out, you could be in for a nice surprise bill from GCP.
 - Worker MIGs are currently zonal, meaning they're confined to a single zone in the deployed region. This leaves them more vulnerable to zonal outages.
 
 # Terraform Module
@@ -48,8 +46,8 @@ There are some quirks and things to be careful about when operating this module.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.7.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 6.10.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.7.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 6.10 |
 
 ## Modules
 
@@ -65,19 +63,9 @@ There are some quirks and things to be careful about when operating this module.
 | Name | Type |
 |------|------|
 | [google-beta_google_compute_region_autoscaler.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_region_autoscaler) | resource |
-| [google_compute_firewall.ilb](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_firewall.ilb_health_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_forwarding_rule.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_compute_instance.metrics](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
-| [google_compute_region_backend_service.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_backend_service) | resource |
-| [google_compute_region_health_check.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_health_check) | resource |
-| [google_compute_region_target_http_proxy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_target_http_proxy) | resource |
-| [google_compute_region_url_map.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_url_map) | resource |
 | [google_compute_router.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
-| [google_compute_subnetwork.ilb_proxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
-| [google_dns_managed_zone.workers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
-| [google_dns_record_set.workers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_project_service.cloud_logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.cloud_monitoring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_project_service.cloud_run](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
@@ -95,9 +83,8 @@ There are some quirks and things to be careful about when operating this module.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_opentelemetry_collector_image"></a> [opentelemetry\_collector\_image](#input\_opentelemetry\_collector\_image) | Address of the container image to use for the OpenTelemetry Collector | `string` | n/a | yes |
-| <a name="input_queue_id"></a> [queue\_id](#input\_queue\_id) | The queue id for the worker | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region in which we're rolling out IaC | `string` | n/a | yes |
-| <a name="input_worker_groups"></a> [worker\_groups](#input\_worker\_groups) | Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc. The 'gpus' block is only appropriate for N1 series VMs with attached GPUs. If any other instance type is specified (like accelerator-optimized VMs), the 'gpus' block will be ignored.) | <pre>map(object({<br/>    queue_id      = string<br/>    instance_type = string<br/>    cpus          = number<br/>    gpus = optional(object({<br/>      count = number<br/>      type  = string<br/>    }))<br/>  }))</pre> | n/a | yes |
+| <a name="input_worker_groups"></a> [worker\_groups](#input\_worker\_groups) | Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc. The 'gpus' block is only appropriate for N1 series VMs with attached GPUs. If any other instance type is specified (like accelerator-optimized VMs), the 'gpus' block will be ignored.) | <pre>map(object({<br/>    queue_id      = string<br/>    instance_type = string<br/>    cpus          = number<br/>    gpus = optional(object({<br/>      count = number<br/>      type  = string<br/>    }))<br/>    max_workers = optional(number, 10)<br/>    min_workers = optional(number, 1)<br/>  }))</pre> | n/a | yes |
 | <a name="input_worker_image"></a> [worker\_image](#input\_worker\_image) | Address of the container image to use for the worker | `string` | n/a | yes |
 
 ## Outputs

--- a/app/deploy/gcp/example.tfvars
+++ b/app/deploy/gcp/example.tfvars
@@ -1,5 +1,5 @@
 region                        = "us-central1"
-worker_image                  = "docker.io/michaelendsley/worker:0.3.2"
+worker_image                  = "metapage/metaframe-docker-worker:0.40.4-standalone"
 opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector-contrib:0.113.0"
 
 worker_groups = {

--- a/app/deploy/gcp/example.tfvars
+++ b/app/deploy/gcp/example.tfvars
@@ -1,11 +1,10 @@
-# Queue ID should be a secret later, but for development is fine supplied in var/objects
-queue_id                      = "81e93644-4af2-11ef-a58f-676a7833797e"
 region                        = "us-central1"
-worker_image                  = "docker.io/michaelendsley/worker:0.3.1"
+worker_image                  = "docker.io/michaelendsley/worker:0.3.2"
 opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector-contrib:0.113.0"
 
 worker_groups = {
   a = {
+    # Queue IDs should later be supplied/retrieved secretly, not stored in code
     queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
     instance_type = "n1-standard-1"
     cpus          = 1
@@ -13,20 +12,22 @@ worker_groups = {
   b = {
     queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
     instance_type = "n1-standard-2"
-    min_workers   = 2
+    min_workers   = 0
     max_workers   = 6
     cpus          = 2
   }
   # A worker group of basic N1 series VMs with attached GPUs
-  # c = {
-  #   queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
-  #   instance_type = "n1-standard-1"
-  #   cpus          = 1
-  #   gpus = {
-  #     type  = "nvidia-tesla-t4"
-  #     count = 1
-  #   }
-  # }
+  c = {
+    queue_id      = "4195a148-baac-11ef-b438-a71e6014b28e"
+    instance_type = "n1-standard-1"
+    cpus          = 1
+    gpus = {
+      type  = "nvidia-tesla-t4"
+      count = 1
+    }
+    min_workers = 0
+    max_workers = 3
+  }
   # A worker group of accelerator-optimized VMs which come with their own GPUs
   # d = {
   #   queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"

--- a/app/deploy/gcp/main.tf
+++ b/app/deploy/gcp/main.tf
@@ -121,6 +121,10 @@ module "worker_vm" {
     image = var.worker_image
     env = [
       {
+        name  = "METAPAGE_GENERATE_WORKER_ID"
+        value = true
+      },
+      {
         name  = "METAPAGE_WORKER_CPUS"
         value = each.value.cpus
       },

--- a/app/deploy/gcp/main.tf
+++ b/app/deploy/gcp/main.tf
@@ -1,0 +1,184 @@
+## Enable the various GCP APIs that this infra uses
+
+resource "google_project_service" "compute" {
+  service                    = "compute.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "iam" {
+  service                    = "iam.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "cloud_monitoring" {
+  service                    = "monitoring.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "cloud_logging" {
+  service                    = "logging.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "cloud_run" {
+  service                    = "run.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "cloud_trace" {
+  service                    = "cloudtrace.googleapis.com"
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+data "project_id" "this" {}
+
+data "google_compute_network" "default" {
+  name = "default"
+}
+
+data "google_compute_subnetwork" "default" {
+  name   = "default"
+  region = var.region
+}
+
+resource "google_service_account" "mig_template_creator" {
+  account_id   = "mig-template-creator"
+  display_name = "Service account for creating mig templates from Terraform"
+}
+
+resource "google_compute_router" "this" {
+  name    = "worker"
+  network = data.google_compute_network.default.self_link
+  region  = var.region
+}
+
+resource "google_compute_router_nat" "this" {
+  name                               = "worker"
+  router                             = google_compute_router.this.name
+  region                             = google_compute_router.this.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+module "gce-container" {
+  source  = "terraform-google-modules/container-vm/google"
+  version = "~> 3.2"
+
+  container = {
+    image = var.worker_image
+    env = [
+      {
+        name  = "METAPAGE_WORKER_CPUS"
+        value = "1"
+      },
+      {
+        name  = "METAPAGE_QUEUE_ID"
+        value = var.queue_id
+      },
+      # {
+      #   name  = "METAPAGE_GENERATE_WORKER_ID"
+      #   value = "true"
+      # }
+    ]
+    securityContext = {
+      privileged : true
+    }
+    tty : true
+    ports = [
+      {
+        name           = "http"
+        container_port = 8080
+      }
+    ]
+    volumeMounts = [
+      {
+        mountPath = "/var/run/docker.sock"
+        name      = "docker-socket"
+        readOnly  = true
+      }
+    ]
+  }
+
+  volumes = [
+    {
+      name = "docker-socket"
+      hostPath = {
+        path = "/var/run/docker.sock"
+      }
+    }
+  ]
+
+  restart_policy = "Always"
+}
+
+module "mig_template" {
+  source     = "terraform-google-modules/vm/google//modules/instance_template"
+  version    = "~> 12.1.0"
+  network    = data.google_compute_network.default.self_link
+  subnetwork = data.google_compute_subnetwork.default.self_link
+  service_account = {
+    email  = google_service_account.mig_template_creator.email
+    scopes = ["cloud-platform"]
+  }
+  name_prefix          = "worker-"
+  preemptible          = true
+  source_image_family  = "cos-stable"
+  source_image_project = "cos-cloud"
+  source_image         = reverse(split("/", module.gce-container.source_image))[0]
+  metadata = {
+    "google-logging-enabled"    = "true"
+    "gce-container-declaration" = module.gce-container.metadata_value
+  }
+  tags = [
+    "worker"
+  ]
+  labels = {
+    "container-vm" = module.gce-container.vm_container_label
+  }
+}
+
+module "mig" {
+  source            = "terraform-google-modules/vm/google//modules/mig"
+  version           = "~> 12.1.0"
+  instance_template = module.mig_template.self_link
+  region            = var.region
+  hostname          = "worker"
+  target_size       = 2
+
+  # distribution_policy_zones = ["us-central1-a"]
+  named_ports = [
+    {
+      name = "http",
+      port = 8080
+    },
+    {
+      name = "ssh",
+      port = 22
+    }
+  ]
+}
+
+module "opentelemetry_service_account" {
+  source     = "terraform-google-modules/service-accounts/google"
+  version    = "~> 4.2"
+  project_id = data.project_id.this
+  prefix     = "worker"
+  names      = ["opentelemetry"]
+}
+
+module "opentelemetry_cloud_run" {
+  source  = "GoogleCloudPlatform/cloud-run/google"
+  version = "~> 0.12"
+
+  service_name          = "opentelemetry"
+  project_id            = data.project_id.this
+  location              = var.region
+  image                 = "otel/opentelemetry-collector:0.112.0"
+  service_account_email = module.service_account.email
+}

--- a/app/deploy/gcp/providers.tf
+++ b/app/deploy/gcp/providers.tf
@@ -6,9 +6,17 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.7.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.10"
+    }
   }
 }
 
 provider "google" {
+  region = "us-central1"
+}
+
+provider "google-beta" {
   region = "us-central1"
 }

--- a/app/deploy/gcp/providers.tf
+++ b/app/deploy/gcp/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.9.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.7.0"
+    }
+  }
+}
+
+provider "google" {
+  region = "us-central1"
+}

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -2,4 +2,4 @@
 queue_id                      = "81e93644-4af2-11ef-a58f-676a7833797e"
 region                        = "us-central1"
 worker_image                  = "docker.io/michaelendsley/worker:latest"
-opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector:0.113.0"
+opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector-contrib:0.113.0"

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -13,18 +13,20 @@ worker_groups = {
   # b = {
   #   queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
   #   instance_type = "n4-standard-2"
+  #   min_workers   = 2
+  #   max_workers   = 6
   #   cpus          = 2
   # }
   # A worker group of basic N1 series VMs with attached GPUs
-  c = {
-    queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
-    instance_type = "n1-standard-1"
-    cpus          = 1
-    gpus = {
-      type  = "nvidia-tesla-t4"
-      count = 1
-    }
-  }
+  # c = {
+  #   queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
+  #   instance_type = "n1-standard-1"
+  #   cpus          = 1
+  #   gpus = {
+  #     type  = "nvidia-tesla-t4"
+  #     count = 1
+  #   }
+  # }
   # A worker group of accelerator-optimized VMs which come with their own GPUs
   # d = {
   #   queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -7,12 +7,28 @@ opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector-contrib:
 worker_groups = {
   a = {
     queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
-    instance_type = "n4-standard-2"
-    cpus          = 2
+    instance_type = "n1-standard-1"
+    cpus          = 1
   }
-  b = {
-    queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
-    instance_type = "n4-standard-4"
-    cpus          = 4
+  # b = {
+  #   queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
+  #   instance_type = "n4-standard-2"
+  #   cpus          = 2
+  # }
+  # A worker group of basic N1 series VMs with attached GPUs
+  c = {
+    queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
+    instance_type = "n1-standard-1"
+    cpus          = 1
+    gpus = {
+      type  = "nvidia-tesla-t4"
+      count = 1
+    }
   }
+  # A worker group of accelerator-optimized VMs which come with their own GPUs
+  # d = {
+  #   queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
+  #   instance_type = "g2-standard-4"
+  #   cpus          = 4
+  # }
 }

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -1,0 +1,4 @@
+# Queue ID should be a secret later, but for development is fine supplied in var/objects
+queue_id     = "81e93644-4af2-11ef-a58f-676a7833797e"
+region       = "us-central1"
+worker_image = "docker.io/michaelendsley/worker:latest"

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -1,7 +1,7 @@
 # Queue ID should be a secret later, but for development is fine supplied in var/objects
 queue_id                      = "81e93644-4af2-11ef-a58f-676a7833797e"
 region                        = "us-central1"
-worker_image                  = "docker.io/michaelendsley/worker:latest"
+worker_image                  = "docker.io/michaelendsley/worker:0.3.1"
 opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector-contrib:0.113.0"
 
 worker_groups = {

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -3,3 +3,16 @@ queue_id                      = "81e93644-4af2-11ef-a58f-676a7833797e"
 region                        = "us-central1"
 worker_image                  = "docker.io/michaelendsley/worker:latest"
 opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector-contrib:0.113.0"
+
+worker_groups = {
+  a = {
+    queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"
+    instance_type = "n4-standard-2"
+    cpus          = 2
+  }
+  b = {
+    queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
+    instance_type = "n4-standard-4"
+    cpus          = 4
+  }
+}

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -1,4 +1,5 @@
 # Queue ID should be a secret later, but for development is fine supplied in var/objects
-queue_id     = "81e93644-4af2-11ef-a58f-676a7833797e"
-region       = "us-central1"
-worker_image = "docker.io/michaelendsley/worker:latest"
+queue_id                      = "81e93644-4af2-11ef-a58f-676a7833797e"
+region                        = "us-central1"
+worker_image                  = "docker.io/michaelendsley/worker:latest"
+opentelemetry_collector_image = "docker.io/otel/opentelemetry-collector:0.113.0"

--- a/app/deploy/gcp/variables.auto.tfvars
+++ b/app/deploy/gcp/variables.auto.tfvars
@@ -10,13 +10,13 @@ worker_groups = {
     instance_type = "n1-standard-1"
     cpus          = 1
   }
-  # b = {
-  #   queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
-  #   instance_type = "n4-standard-2"
-  #   min_workers   = 2
-  #   max_workers   = 6
-  #   cpus          = 2
-  # }
+  b = {
+    queue_id      = "652ab68e-5f7b-11ef-b136-6f3c51289ae7"
+    instance_type = "n1-standard-2"
+    min_workers   = 2
+    max_workers   = 6
+    cpus          = 2
+  }
   # A worker group of basic N1 series VMs with attached GPUs
   # c = {
   #   queue_id      = "81e93644-4af2-11ef-a58f-676a7833797e"

--- a/app/deploy/gcp/variables.tf
+++ b/app/deploy/gcp/variables.tf
@@ -27,6 +27,8 @@ variable "worker_groups" {
       count = number
       type  = string
     }))
+    max_workers = optional(number, 10)
+    min_workers = optional(number, 1)
   }))
   description = "Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc. The 'gpus' block is only appropriate for N1 series VMs with attached GPUs. If any other instance type is specified (like accelerator-optimized VMs), the 'gpus' block will be ignored.)"
 }

--- a/app/deploy/gcp/variables.tf
+++ b/app/deploy/gcp/variables.tf
@@ -1,8 +1,3 @@
-variable "queue_id" {
-  type        = string
-  description = "The queue id for the worker"
-}
-
 variable "region" {
   type        = string
   description = "The region in which we're rolling out IaC"

--- a/app/deploy/gcp/variables.tf
+++ b/app/deploy/gcp/variables.tf
@@ -8,6 +8,11 @@ variable "region" {
   description = "The region in which we're rolling out IaC"
 }
 
+variable "opentelemetry_collector_image" {
+  type        = string
+  description = "Address of the container image to use for the OpenTelemetry Collector"
+}
+
 variable "worker_image" {
   type        = string
   description = "Address of the container image to use for the worker"

--- a/app/deploy/gcp/variables.tf
+++ b/app/deploy/gcp/variables.tf
@@ -23,6 +23,10 @@ variable "worker_groups" {
     queue_id      = string
     instance_type = string
     cpus          = number
+    gpus = optional(object({
+      count = number
+      type  = string
+    }))
   }))
-  description = "Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc.)"
+  description = "Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc. The 'gpus' block is only appropriate for N1 series VMs with attached GPUs. If any other instance type is specified (like accelerator-optimized VMs), the 'gpus' block will be ignored.)"
 }

--- a/app/deploy/gcp/variables.tf
+++ b/app/deploy/gcp/variables.tf
@@ -1,0 +1,14 @@
+variable "queue_id" {
+  type        = string
+  description = "The queue id for the worker"
+}
+
+variable "region" {
+  type        = string
+  description = "The region in which we're rolling out IaC"
+}
+
+variable "worker_image" {
+  type        = string
+  description = "Address of the container image to use for the worker"
+}

--- a/app/deploy/gcp/variables.tf
+++ b/app/deploy/gcp/variables.tf
@@ -17,3 +17,12 @@ variable "worker_image" {
   type        = string
   description = "Address of the container image to use for the worker"
 }
+
+variable "worker_groups" {
+  type = map(object({
+    queue_id      = string
+    instance_type = string
+    cpus          = number
+  }))
+  description = "Definitions of autoscaling worker groups to create. Map key will be used as the name of the worker group, so make sure it's DNS-friendly (no spaces, incompatible special characters, etc.)"
+}


### PR DESCRIPTION
There is still some cleanup, enhancement, and deeper testing needed for this work, but all the basic functionality is available and ready to be tried out, and I'd like to solicit feedback at this stage.

Applying the IaC under `app/deploy/gcp` will create all the resources necessary for managing multiple auto-scaling groups of workers, which will scale out and in based on the number of unfinished jobs in their respective queues. You can edit and define new groups in `variables.auto.tfvars`.

There are a number of moving parts to get this working on GCP, and I think it's valuable to understand them all if possible, so I will be further expanding the documentation as well as polishing the module. Any and all questions are greatly appreciated.