### PR TITLE
101/browser-client-local

### DIFF
--- a/app/browser/src/components/sections/queue/LocalModeToggle.tsx
+++ b/app/browser/src/components/sections/queue/LocalModeToggle.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback, useEffect, useState } from "react";
+
+import { HouseLine } from "@phosphor-icons/react";
+
+import { Button, Icon, Tooltip } from "@chakra-ui/react";
+import { useHashParam } from "@metapages/hash-query/react-hooks";
+
+export const LocalModeToggle: React.FC = () => {
+  const [queue, setQueue] = useHashParam("queue", "");
+  const [isLocalMode, setIsLocalMode] = useState<boolean>(queue === "local");
+  useEffect(() => {
+    setIsLocalMode(queue === "local");
+  }, [queue]);
+
+  const onToggle = useCallback(() => {
+    if (queue === "local") {
+      const previousQueue = localStorage.getItem("previous-queue");
+      if (previousQueue) {
+        setQueue(previousQueue);
+      } else {
+        setQueue("");
+      }
+    } else {
+      localStorage.setItem("previous-queue", queue);
+      setQueue("local");
+    }
+  }, [queue, setQueue]);
+
+  return (
+    <Tooltip label={isLocalMode ? "Enable remote mode" : "Enable local mode"}>
+      {/* onFocus https://github.com/chakra-ui/chakra-ui/issues/5304#issuecomment-1102836734 */}
+      <Button minWidth={200} onFocus={e => e.preventDefault()} pr={10} variant="ghost" leftIcon={<Icon as={HouseLine} boxSize={6} />} onClick={onToggle} aria-label="local mode">
+        {isLocalMode ? "Local Mode" : "Remote Mode"}
+      </Button>
+    </Tooltip>
+  );
+};

--- a/app/browser/src/components/sections/queue/Queue.tsx
+++ b/app/browser/src/components/sections/queue/Queue.tsx
@@ -1,12 +1,12 @@
+import { QuestionIcon } from "@chakra-ui/icons";
+import { HStack, Tab, TabList, TabPanel, TabPanels, Tabs, VStack } from "@chakra-ui/react";
 import React from "react";
-import { HStack, VStack, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import { useActiveJobsCount } from "/@/hooks/useActiveJobsCount";
 import { useWorkersCount } from "/@/hooks/useWorkersCount";
-import { QuestionIcon } from "@chakra-ui/icons";
 
+import { QueueButtonAndLabel } from "./QueueButtonAndLabel";
 import { JobsTable } from "/@/components/sections/queue/JobsTable";
 import { WorkersTable } from "/@/components/sections/queue/WorkersTable";
-import { QueueButtonAndLabel } from "./QueueButtonAndLabel";
 
 export const Queue: React.FC = () => {
   const activeJobsCount = useActiveJobsCount();

--- a/app/browser/src/config.tsx
+++ b/app/browser/src/config.tsx
@@ -1,5 +1,6 @@
 const serverOrigin = import.meta.env.VITE_SERVER_ORIGIN || globalThis.location.origin;
-// console.log('VITE_SERVER_ORIGIN', import.meta.env.VITE_SERVER_ORIGIN)
-// console.log('serverOrigin', serverOrigin)
 export const websocketConnectionUrl = `${serverOrigin.replace("http", "ws")}${serverOrigin.endsWith("/") ? "" : "/"}`;
 export const UPLOAD_DOWNLOAD_BASE_URL = serverOrigin;
+// local mode where the worker is running on the same machine as the browser
+// and acts as the queue API combined with the job worker
+export const websocketConnectionUrlLocalmode = "ws://localhost:8000/";

--- a/app/browser/src/hooks/serverWebsocket.tsx
+++ b/app/browser/src/hooks/serverWebsocket.tsx
@@ -15,14 +15,14 @@ import ReconnectingWebSocket from "reconnecting-websocket";
 
 import { useHashParam } from "@metapages/hash-query/react-hooks";
 
-import { websocketConnectionUrl } from "../config";
+import { websocketConnectionUrl, websocketConnectionUrlLocalmode } from "../config";
 import { cacheInsteadOfSendMessages, useStore } from "../store";
 
 /**
  * Sets states bits in the store
  */
 export const serverWebsocket = (): void => {
-  const [address] = useHashParam("queue");
+  const [queue] = useHashParam("queue");
 
   const setIsServerConnected = useStore(state => state.setIsServerConnected);
 
@@ -37,10 +37,10 @@ export const serverWebsocket = (): void => {
   const handleJobStatusPayload = useStore(state => state.handleJobStatusPayload);
 
   useEffect(() => {
-    if (!address || address === "") {
+    if (!queue || queue === "") {
       return;
     }
-    const url = `${websocketConnectionUrl}${address}/client`;
+    const url = `${queue === "local" ? websocketConnectionUrlLocalmode : websocketConnectionUrl}${queue}/client`;
     setIsServerConnected(false);
     const rws = new ReconnectingWebSocket(url);
     let timeLastPong = Date.now();
@@ -151,5 +151,5 @@ export const serverWebsocket = (): void => {
       setIsServerConnected(false);
       setSendMessage(cacheInsteadOfSendMessages);
     };
-  }, [address, setSendMessage, setIsServerConnected, setRawMessage]);
+  }, [queue, setSendMessage, setIsServerConnected, setRawMessage]);
 };


### PR DESCRIPTION
Fixes #101

`local` mode connects to `ws://localhost:8000` instead of the remote api server

<img width="564" alt="image" src="https://github.com/user-attachments/assets/c8bf4e2f-8a5f-4aeb-8ccc-c71ac66f2e05">
