### PR TITLE
Add a centralized queue metrics endpoint

### DIFF
--- a/app/api/src/handlerHono.ts
+++ b/app/api/src/handlerHono.ts
@@ -40,6 +40,7 @@ app.get('/healthz', (c :Context) => c.text('OK'))
 app.get('/download/:key', downloadHandler)
 app.get('/upload/:key', uploadHandler)
 app.get('/:queue/status', statusHandler)
+app.get('/:queue/metrics', metricsHandler)
 
 // Serve static assets, and the index.html as the fallback
 app.get('/*', serveStatic({ root: './assets' }));

--- a/app/api/src/handlerHono.ts
+++ b/app/api/src/handlerHono.ts
@@ -11,6 +11,7 @@ import {
 
 import { downloadHandler } from './routes/download.ts';
 import { statusHandler } from './routes/status.ts';
+import { metricsHandler } from './routes/metrics.ts';
 import { uploadHandler } from './routes/upload.ts';
 
 const app = new Hono()

--- a/app/api/src/routes/metrics.ts
+++ b/app/api/src/routes/metrics.ts
@@ -2,12 +2,13 @@ import { Context } from 'https://deno.land/x/hono@v4.1.0-rc.1/mod.ts';
 
 import { statusHandler } from '../routes/status.ts';
 import { DockerJobState } from '../shared/mod.ts';
+import { userJobQueues } from '../docker-jobs/ApiDockerJobQueue.ts';
 
 export const metricsHandler = async (c: Context) => {
   const statusResponse = await statusHandler(c);
 
-  // If response isn't success code, return it as is
-  if (c.status() < 200 || c.status() >= 300) {
+  // If response isn't success code or 404 (which we treat as empty queue), return it as is
+  if (c.res.status < 200 || c.res.status >= 300 && c.res.status !== 404) {
     console.error(`Failed to get status, got: ${statusResponse.status} instead`);
     return statusResponse;
   }
@@ -22,7 +23,8 @@ export const metricsHandler = async (c: Context) => {
       console.debug("Treating a null queue as a queue with no jobs");
       unfinishedQueueLength = 0;
     } else {
-      unfinishedJobs = Object.values(responseData.jobs).filter((job) => job.state !== DockerJobState.Finished);
+      unfinishedJobs = Object.values(responseData.jobs as Record<string, { state: DockerJobState }>)
+        .filter((job) => job.state !== DockerJobState.Finished);
       unfinishedQueueLength = unfinishedJobs.length;
     }
 

--- a/app/api/src/routes/metrics.ts
+++ b/app/api/src/routes/metrics.ts
@@ -1,0 +1,46 @@
+import { Context } from 'https://deno.land/x/hono@v4.1.0-rc.1/mod.ts';
+
+import { statusHandler } from '../routes/status.ts';
+import { DockerJobState } from '../shared/mod.ts';
+
+export const metricsHandler = async (c: Context) => {
+  const statusResponse = await statusHandler(c);
+
+  // If response isn't success code, return it as is
+  if (c.status() < 200 || c.status() >= 300) {
+    console.error(`Failed to get status, got: ${statusResponse.status} instead`);
+    return statusResponse;
+  }
+
+  let unfinishedJobs;
+  let unfinishedQueueLength;
+
+  try {
+    const responseData = await statusResponse.json();
+
+    if (!responseData.jobs) {
+      console.debug("Treating a null queue as a queue with no jobs");
+      unfinishedQueueLength = 0;
+    } else {
+      unfinishedJobs = Object.values(responseData.jobs).filter((job) => job.state !== DockerJobState.Finished);
+      unfinishedQueueLength = unfinishedJobs.length;
+    }
+
+    // Simple Prometheus-compatible metric response
+    const response = `
+# HELP queue_length The number of outstanding jobs in the queue
+# TYPE queue_length gauge
+queue_length ${unfinishedQueueLength}
+`;
+
+    return new Response(response, {
+      status: 200,
+      headers: {
+        "content-type": "text/plain",
+      },
+    });
+  } catch (e) {
+    console.error(`Error processing jobs data for metrics: ${e}`);
+    return new Response("Error processing jobs data for metrics", { status: 500 });
+  }
+};


### PR DESCRIPTION
As the commit says, this centralized /metrics endpoint (in the same format as /status) on the public API will let us fetch prometheus-compatible metrics without requiring a worker to be running. This allows for scale-to-zero as long as the autoscaler in charge can fetch the API's endpoint.

This is a pre-requisite PR for modifying #87 to include scale-to-zero functionality. I need the public API providing this metric in order to test it live in GCP.