### PR TITLE
better-metrics

### DIFF
--- a/app/api/src/db/kv/mod.ts
+++ b/app/api/src/db/kv/mod.ts
@@ -57,7 +57,6 @@ export class DB {
     }
 
     async queueGetAll(queue: string): Promise<DockerJobDefinitionRow[]> {
-
         const entries = kv.list<DataRef<DockerJobDefinitionRow>>({ prefix: ["queue", queue] });
         const results : DockerJobDefinitionRow[] = [];
         for await (const entry of entries) {
@@ -73,6 +72,16 @@ export class DB {
             }
         }
         return results;
+    }
+
+    async queueGetCount(queue: string): Promise<number> {
+        const entries = kv.list<DataRef<DockerJobDefinitionRow>>({ prefix: ["queue", queue] });
+        
+        let count = 0;
+        for await (const _ of entries) {
+            count++;
+        }
+        return count;
     }
 
     async resultCacheAdd(id: string, result: DockerJobDefinitionRow): Promise<void> {

--- a/app/api/src/routes/metrics.ts
+++ b/app/api/src/routes/metrics.ts
@@ -1,38 +1,23 @@
 import { Context } from 'https://deno.land/x/hono@v4.1.0-rc.1/mod.ts';
 
-import { statusHandler } from '../routes/status.ts';
-import { DockerJobState } from '../shared/mod.ts';
-import { userJobQueues } from '../docker-jobs/ApiDockerJobQueue.ts';
+import { db } from '../db/kv/mod.ts';
 
 export const metricsHandler = async (c: Context) => {
-  const statusResponse = await statusHandler(c);
+  const queue: string | undefined = c.req.param("queue");
 
-  // If response isn't success code or 404 (which we treat as empty queue), return it as is
-  if (c.res.status < 200 || c.res.status >= 300 && c.res.status !== 404) {
-    console.error(`Failed to get status, got: ${statusResponse.status} instead`);
-    return statusResponse;
+  if (!queue) {
+    c.status(400);
+    return c.text("Missing queue");
   }
 
-  let unfinishedJobs;
-  let unfinishedQueueLength;
+  const count = await db.queueGetCount(queue);
 
   try {
-    const responseData = await statusResponse.json();
-
-    if (!responseData.jobs) {
-      console.debug("Treating a null queue as a queue with no jobs");
-      unfinishedQueueLength = 0;
-    } else {
-      unfinishedJobs = Object.values(responseData.jobs as Record<string, { state: DockerJobState }>)
-        .filter((job) => job.state !== DockerJobState.Finished);
-      unfinishedQueueLength = unfinishedJobs.length;
-    }
-
     // Simple Prometheus-compatible metric response
     const response = `
 # HELP queue_length The number of outstanding jobs in the queue
 # TYPE queue_length gauge
-queue_length ${unfinishedQueueLength}
+queue_length ${count}
 `;
 
     return new Response(response, {


### PR DESCRIPTION
Use the queue in the db instead of the in memory queue to avoid complicated quering of worker nodes
