### PR TITLE
client-refreshes-s3-links-always

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.0.3
+          deno-version: v2.1.4
 
       - name: Check formatting
         run: just fmt --check

--- a/.github/workflows/publish-worker.yml
+++ b/.github/workflows/publish-worker.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: "2.0.3"
+          deno-version: "2.1.4"
 
       - name: Build and release
         env:

--- a/README.md
+++ b/README.md
@@ -57,11 +57,8 @@ flowchart LR
 - `deno`: https://docs.deno.com/runtime/manual/getting_started/installation
 - `mkcert`: https://github.com/FiloSottile/mkcert
   - ❗ 👉 Make sure you run `mkcert -install` ❗
-  - Add `127.0.0.1   app.metapage.localhost` to `/etc/hosts` by
-  - `sudo vi /etc/hosts`
-  - Then paste in:
-    - `127.0.0.1       app.metapage.localhost`
 
+Run the local stack:
 ```
 just dev
 ```
@@ -76,6 +73,13 @@ hono webserver).
 
 You can edit browser code, worker code, api code, and CLI and everything
 automatically updates.
+
+### Tests
+
+ - `just test`: runs the entire test suite, creating a new local stack
+   - runs on every push to non-main branches
+ - `just api/test/watch`: (requires a running local stack) runs functional tests, currently only permissions
+   - see `just api/test` for more test related commands
 
 ### Start each service separately
 
@@ -171,6 +175,4 @@ used directly, or a git repo can be given, and the docker image built directly.
 This repo contains all the infrastructure for the queues, workers, and examples
 of cloud providers managing the horizintal scaling worker fleets.
 
-## Misc testing
 
-[local](http://localhost:8080/)

--- a/app/api/src/docker-jobs/ApiDockerJobQueue.ts
+++ b/app/api/src/docker-jobs/ApiDockerJobQueue.ts
@@ -290,7 +290,7 @@ export class ApiDockerJobQueue {
             );
             this.broadcastJobStatesToWebsockets(jobIds);
           } else {
-            console.log(`🌘 ...from merge complete, no changes!`);
+            // console.log(`🌘 ...from merge complete, no changes!`);
           }
           break;
 

--- a/app/api/src/handlerHono.ts
+++ b/app/api/src/handlerHono.ts
@@ -6,10 +6,12 @@ import {
 } from "https://deno.land/x/hono@v4.1.0-rc.1/middleware/cors/index.ts";
 import { Context, Hono } from "https://deno.land/x/hono@v4.1.0-rc.1/mod.ts";
 
-import { downloadHandler } from "./routes/download.ts";
+import { downloadHandler } from "./routes/api/v1/download.ts";
 import { statusHandler } from "./routes/status.ts";
 import { metricsHandler } from "./routes/metrics.ts";
-import { uploadHandler } from "./routes/upload.ts";
+import { uploadHandler } from "./routes/api/v1/upload.ts";
+import { uploadHandler as uploadHandlerDeprecated } from "./routes/deprecated/upload.ts";
+import { downloadHandler as downloadHandlerDeprecated } from "./routes/deprecated/download.ts";
 
 const app = new Hono();
 
@@ -32,8 +34,15 @@ app.use("/*", cors() // cors({
 
 // Put your custom routes here
 app.get("/healthz", (c: Context) => c.text("OK"));
-app.get("/download/:key", downloadHandler);
-app.get("/upload/:key", uploadHandler);
+
+app.get("/api/v1/download/:key", downloadHandler);
+app.put("/api/v1/upload/:key", uploadHandler);
+
+// @deprecated
+app.get("/upload/:key", uploadHandlerDeprecated);
+// @deprecated
+app.get("/download/:key", downloadHandlerDeprecated);
+
 app.get("/:queue/status", statusHandler);
 app.get("/:queue/metrics", metricsHandler);
 

--- a/app/api/src/routes/api/v1/download.ts
+++ b/app/api/src/routes/api/v1/download.ts
@@ -1,19 +1,16 @@
-import { DataRefType } from "/@/shared";
 import { Context } from "https://deno.land/x/hono@v4.1.0-rc.1/mod.ts";
 import { GetObjectCommand } from "npm:@aws-sdk/client-s3";
 import { getSignedUrl } from "npm:@aws-sdk/s3-request-presigner";
 
-import { bucketParams, s3Client } from "./s3config.ts";
+import { bucketParams, s3Client } from "../../s3config.ts";
 
 export const downloadHandler = async (c: Context) => {
   const key: string | undefined = c.req.param("key");
-
   if (!key) {
     c.status(400);
     return c.text("Missing key");
   }
   // console.log('params', params);
-
   // Add headers for
   // https://www.reddit.com/r/aws/comments/j5lhhn/limiting_the_s3_put_file_size_using_presigned_urls/
   // In your service that's generating pre-signed URLs, use the Content-Length header as part of the V4 signature (and accept object size as a parameter from the app). In the client, specify the Content-Length when uploading to S3.
@@ -23,12 +20,8 @@ export const downloadHandler = async (c: Context) => {
   // ContentType?: string;
   const command = new GetObjectCommand({ ...bucketParams, Key: key });
   let url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
-  url = url.replace("http://", "https://");
-  return c.json({
-    url,
-    ref: {
-      value: url,
-      type: DataRefType.url,
-    },
-  });
+  if (url.startsWith("http://")) {
+    url = url.replace("http://", "https://");
+  }
+  return c.redirect(url);
 };

--- a/app/api/src/routes/api/v1/upload.ts
+++ b/app/api/src/routes/api/v1/upload.ts
@@ -1,0 +1,33 @@
+import { Context } from "https://deno.land/x/hono@v4.1.0-rc.1/mod.ts";
+import { PutObjectCommand } from "npm:@aws-sdk/client-s3";
+import { getSignedUrl } from "npm:@aws-sdk/s3-request-presigner";
+
+import { bucketParams, s3Client } from "../../s3config.ts";
+
+export const uploadHandler = async (c: Context) => {
+  const key: string | undefined = c.req.param("key");
+
+  if (!key) {
+    c.status(400);
+    return c.text("Missing key");
+  }
+  // Add headers for
+  // https://www.reddit.com/r/aws/comments/j5lhhn/limiting_the_s3_put_file_size_using_presigned_urls/
+  // In your service that's generating pre-signed URLs, use the Content-Length header as part of the V4 signature (and accept object size as a parameter from the app). In the client, specify the Content-Length when uploading to S3.
+  // Your service can then refuse to provide a pre-signed URL for any object larger than some configured size.
+  //  ContentLength: 4
+  // ContentMD5?: string;
+  // ContentType?: string;
+  const command = new PutObjectCommand({ ...bucketParams, Key: key });
+  try {
+    let url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+    if (url.startsWith("http://")) {
+      url = url.replace("http://", "https://");
+    }
+    return c.redirect(url);
+  } catch (err) {
+    console.error("uploadHandler error", err);
+    c.status(500);
+    return c.text("Failed to get signed URL");
+  }
+};

--- a/app/api/src/routes/deprecated/upload.ts
+++ b/app/api/src/routes/deprecated/upload.ts
@@ -1,0 +1,39 @@
+import { DataRefType } from "/@/shared";
+import { Context } from "https://deno.land/x/hono@v4.1.0-rc.1/mod.ts";
+import { PutObjectCommand } from "npm:@aws-sdk/client-s3";
+import { getSignedUrl } from "npm:@aws-sdk/s3-request-presigner";
+
+import { bucketParams, s3Client } from "../s3config.ts";
+
+export const uploadHandler = async (c: Context) => {
+  const key: string | undefined = c.req.param("key");
+
+  if (!key) {
+    c.status(400);
+    return c.text("Missing key");
+  }
+
+  // Add headers for
+  // https://www.reddit.com/r/aws/comments/j5lhhn/limiting_the_s3_put_file_size_using_presigned_urls/
+  // In your service that's generating pre-signed URLs, use the Content-Length header as part of the V4 signature (and accept object size as a parameter from the app). In the client, specify the Content-Length when uploading to S3.
+  // Your service can then refuse to provide a pre-signed URL for any object larger than some configured size.
+  //  ContentLength: 4
+  // ContentMD5?: string;
+  // ContentType?: string;
+  const command = new PutObjectCommand({ ...bucketParams, Key: key });
+  try {
+    let url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+    url = url.replace("http://", "https://");
+    return c.json({
+      url,
+      ref: {
+        value: key, // no http means we know it's an internal address, workers will know how to reach
+        type: DataRefType.key,
+      },
+    });
+  } catch (err) {
+    console.error("uploadHandler error", err);
+    c.status(500);
+    return c.text("Failed to get signed URL");
+  }
+};

--- a/app/browser/src/README.md
+++ b/app/browser/src/README.md
@@ -3,11 +3,10 @@
 - a single websocket on a queue/address does all the communication to the api
   server
 - job flow:
-  - `PanelJobInputFromUrlParams` takes the job parameters and sets it in the url
-    hash `job` param
-  - `jobDefinitionHook` gets the job parameters and combines with the metaframe
-    inputs (which if large are copied to the cloud storage)
-  - `TabMenu` is where the job is actually submitted to the server, via a
-    `StateChangeValueQueued`
-    - This class should be renamed or use a hook so the data flow is not tied up
-      with the UI. I was less familiar with react when I wrote this.
+  - `PanelImageAndContainer` (and others) takes the job parameters and sets it
+    in the url hash `job` param
+  - `useDockerJobDefinition` gets the job parameters and combines with the
+    metaframe inputs (which if large are copied to the cloud storage)
+  - `useJobSubmissionHook` is where the job is actually submitted to the server,
+    via a `StateChangeValueQueued`
+  - `useSendJobOutputs` is where the job outputs are sent to the metaframe

--- a/app/browser/src/hooks/useSendJobOutputs.ts
+++ b/app/browser/src/hooks/useSendJobOutputs.ts
@@ -5,28 +5,21 @@ import {
   DataRef,
   DataRefType,
   DockerJobState,
-  fetchJsonFromUrl,
   StateChangeValueFinished,
 } from "/@/shared";
 
-import { useMetaframeAndInput } from "@metapages/metapage-react";
 import { isIframe, MetaframeInputMap } from "@metapages/metapage";
+import { useMetaframeAndInput } from "@metapages/metapage-react";
 
 import { UPLOAD_DOWNLOAD_BASE_URL } from "../config";
 import { DockerRunResultWithOutputs } from "../shared";
 import { useStore } from "../store";
-import {
-  useOptionJobStartAutomatically,
-} from "./useOptionJobStartAutomatically";
 import { useOptionResolveDataRefs } from "./useOptionResolveDataRefs";
 
 const datarefKeyToUrl = async (ref: DataRef): Promise<DataRef> => {
   if (ref.type === DataRefType.key) {
-    const { url } = await fetchJsonFromUrl<{ url: string }>(
-      `${UPLOAD_DOWNLOAD_BASE_URL}/download/${ref.value}`,
-    );
     return {
-      value: url,
+      value: `${UPLOAD_DOWNLOAD_BASE_URL}/api/v1/download/${ref.value}`,
       type: DataRefType.url,
     };
   } else {
@@ -51,8 +44,6 @@ export const useSendJobOutputs = () => {
   // You usually don't want this on, that means big blobs
   // are going to move around your system
   const [resolveDataRefs] = useOptionResolveDataRefs();
-  const userClickedRun = useStore((state) => state.userClickedRun);
-  const [jobStartsAutomatically] = useOptionJobStartAutomatically();
   const dockerJobServer = useStore((state) => state.jobState);
   // track if we have sent the outputs for this job hash
   // this will be reset if the state isn't finished
@@ -118,11 +109,6 @@ export const useSendJobOutputs = () => {
         try {
           // previously we sent the job status code, logs etc, but just send the outputs
           // If you want to send the other stuff, you can on your own
-          // metaframeObj.setOutputs!({ ...keysToUrlsOutputs, ...theRest });
-          // console.log(
-          //   `💚 resolveDataRefs=true Sending outputs to metaframe`,
-          //   keysToUrlsOutputs
-          // );
           metaframeObj.setOutputs!({ ...keysToUrlsOutputs });
         } catch (err) {
           console.error("Failed to send metaframe outputs", err);

--- a/app/cli/src/commands/worker/workerUpgrade.ts
+++ b/app/cli/src/commands/worker/workerUpgrade.ts
@@ -169,7 +169,7 @@ async function getLatestVersionFromDockerHub(
 
   try {
     // Fetch the tag information from DockerHub
-    const response = await fetch(url);
+    const response = await fetch(url, { redirect: "follow" });
     if (!response.ok) {
       console.error(
         `Failed to fetch tags from DockerHub for image: ${imageName}`,

--- a/app/docker-compose-local.yml
+++ b/app/docker-compose-local.yml
@@ -47,7 +47,6 @@ services:
       - default
     extra_hosts:
       - host.docker.internal:host-gateway
-      - local.storage.local.nhost.run:host-gateway
       - minio.worker-metaframe.localhost:host-gateway
       - worker-metaframe.localhost:host-gateway
     labels:
@@ -85,4 +84,3 @@ services:
       - node_modules:/app/browser/node_modules
     extra_hosts:
       - "host.docker.internal:host-gateway"
-

--- a/app/docker-compose-remote.yml
+++ b/app/docker-compose-remote.yml
@@ -1,42 +1,39 @@
 services:
-  test:
-    depends_on:
-      api1:
-        condition: service_healthy
-    image: denoland/deno:alpine-2.0.3
-    command: deno test --watch --unsafely-ignore-certificate-errors --allow-all --unstable-broadcast-channel --unstable-kv .
-    working_dir: /app/test
-    extra_hosts:
-      - host.docker.internal:host-gateway
-      - minio.worker-metaframe.localhost:host-gateway
-      - worker-metaframe.localhost:host-gateway
-    environment:
-      - NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-}
-      - API_URL=http://api1:8081
-      - DENO_DIR=/deno
-      - DENO_INSTALL_ROOT=/deno
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-minioaccesskey123123}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-minioaccesskey123123}
-      - AWS_REGION=${AWS_REGION:-us-west-2}
-      - AWS_ENDPOINT=${AWS_ENDPOINT:-https://minio.worker-metaframe.localhost}:${APP_PORT:-443}
-      - AWS_S3_BUCKET=${AWS_S3_BUCKET:-localbucket}
-      - DENO_KV_ACCESS_TOKEN=localdenoaccesstoken
-      - DENO_KV_URL=http://denokv:4512
-      - REDIS_URL=redis://redis:6379
-    volumes:
-      - deno:/deno
-      - .:/app
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.api1.rule=Host(`worker-metaframe.localhost`)"
-      - "traefik.http.routers.api1.entrypoints=websecure"
-      - "traefik.http.routers.api1.tls=true"
-      - "traefik.http.services.api1.loadbalancer.server.port=8081"
-    networks:
-      - default
-    logging:
-      driver: ${LOGGING_TESTS:-json-file}
-
+  # test:
+  #   depends_on:
+  #     api1:
+  #       condition: service_healthy
+  #   image: denoland/deno:alpine-2.1.4
+  #   command: deno test --watch --unsafely-ignore-certificate-errors --allow-all --unstable-broadcast-channel --unstable-kv .
+  #   working_dir: /app/test
+  #   extra_hosts:
+  #     - host.docker.internal:host-gateway
+  #     - minio.worker-metaframe.localhost:host-gateway
+  #     - worker-metaframe.localhost:host-gateway
+  #     - worker-metaframe-api2.dev:host-gateway
+  #   environment:
+  #     - IGNORE_CERTIFICATE_ERRORS=true
+  #     - NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-}
+  #     - API_URL=http://api1:8081
+  #     - DENO_DIR=/deno
+  #     - DENO_INSTALL_ROOT=/deno
+  #     - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-minioaccesskey123123}
+  #     - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-minioaccesskey123123}
+  #     - AWS_REGION=${AWS_REGION:-us-west-2}
+  #     - AWS_ENDPOINT=${AWS_ENDPOINT:-https://minio.worker-metaframe.localhost}:${APP_PORT:-443}
+  #     - AWS_S3_BUCKET=${AWS_S3_BUCKET:-localbucket}
+  #     - DENO_KV_ACCESS_TOKEN=localdenoaccesstoken
+  #     - DENO_KV_URL=http://denokv:4512
+  #     - REDIS_URL=redis://redis:6379
+  #   volumes:
+  #     - deno:/deno
+  #     - .:/app
+  #   labels:
+  #     - "custom.label=worker-metaframe.localhost"
+  #   networks:
+  #     - default
+  #   logging:
+  #     driver: ${LOGGING_TESTS:-json-file}
   api1:
     depends_on:
       traefik:
@@ -47,7 +44,7 @@ services:
         condition: service_started
       redis:
         condition: service_healthy
-    image: denoland/deno:alpine-2.0.3
+    image: denoland/deno:alpine-2.1.4
     command: deno run --unsafely-ignore-certificate-errors --watch --allow-all --unstable-broadcast-channel --unstable-kv src/server.ts
     working_dir: /app/api
     healthcheck:
@@ -81,12 +78,11 @@ services:
       - default
     extra_hosts:
       - host.docker.internal:host-gateway
-      - local.graphql.nhost.run:host-gateway
       - minio.worker-metaframe.localhost:host-gateway
       - worker-metaframe.localhost:host-gateway
     labels:
-      - "custom.label=worker-metaframe.localhost"
       - "traefik.enable=true"
+      - "custom.label=worker-metaframe.localhost"
       - "traefik.http.routers.api1.rule=Host(`worker-metaframe.localhost`)"
       - "traefik.http.routers.api1.tls=true"
       - "traefik.http.routers.api1.entrypoints=websecure"
@@ -95,13 +91,9 @@ services:
 
   api2:
     depends_on:
-      minio:
-        condition: service_started
-      denokv:
-        condition: service_started
-      redis:
+      api1:
         condition: service_healthy
-    image: denoland/deno:alpine-2.0.3
+    image: denoland/deno:alpine-2.1.4
     command: deno run --unsafely-ignore-certificate-errors --watch --allow-all --unstable-broadcast-channel --unstable-kv src/server.ts
     working_dir: /app/api
     healthcheck:
@@ -133,16 +125,19 @@ services:
       - default
     extra_hosts:
       - host.docker.internal:host-gateway
-      - local.graphql.nhost.run:host-gateway
       - minio.worker-metaframe.localhost:host-gateway
       - worker-metaframe.localhost:host-gateway
+    labels:
+      - "traefik.enable=true"
+      - "custom.label=worker-metaframe.localhost"
+      - "traefik.http.routers.api2.rule=Host(`worker-metaframe-api2.dev`)"
+      - "traefik.http.routers.api2.tls=true"
+      - "traefik.http.routers.api2.entrypoints=websecure"
     logging:
       driver: ${LOGGING_API:-json-file}
 
   worker:
     depends_on:
-      api1:
-        condition: service_healthy
       api2:
         condition: service_healthy
     entrypoint: [
@@ -153,12 +148,16 @@ services:
       "--allow-all",
       "src/cli.ts",
     ]
-    command: run --cpus=2 --gpus=0 --api-server-address=https://worker-metaframe.localhost:${APP_PORT:-443} local1
+    # Notice that the worker connects to api2 while the browser connects to api1
+    # This helps check api worker communication
+    command: run --cpus=2 --gpus=0 --api-server-address=https://worker-metaframe-api2.dev:${APP_PORT:-443} local1
     build:
       context: .
       dockerfile: worker/Dockerfile
       target: worker
     environment:
+      # APP_PORT is only needed for the upload/curl/dns/docker fiasco
+      - APP_PORT=${APP_PORT:-443}
       - IGNORE_CERTIFICATE_ERRORS=true
       - NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-}
       - DENO_DIR=/deno
@@ -172,9 +171,11 @@ services:
       - node_modules_worker:/app/worker/node_modules
     extra_hosts:
       - host.docker.internal:host-gateway
-      - local.storage.local.nhost.run:host-gateway
       - minio.worker-metaframe.localhost:host-gateway
       - worker-metaframe.localhost:host-gateway
+      - worker-metaframe-api2.dev:host-gateway
+    networks:
+      - default
     logging:
       driver: ${LOGGING_WORKER:-json-file}
 
@@ -203,11 +204,12 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  # ensure the s3 bucket exists in this stack
   create-s3-bucket:
     depends_on:
       minio:
-        condition: service_started
-    image: denoland/deno:alpine-2.0.3
+        condition: service_healthy
+    image: denoland/deno:alpine-2.1.4
     command: deno run --watch --allow-all ./src/s3/create-bucket-development.ts
     working_dir: /app/api
     environment:
@@ -225,7 +227,11 @@ services:
     volumes:
       - ./api/src:/app/api/src
       - deno:/deno
+    networks:
+      - default
 
+  # deno.kv in the cloud is a shared db, in docker-compose we need to
+  # run it as a service to replicate the behavior
   denokv:
     image: ghcr.io/denoland/denokv
     command: --sqlite-path /data/denokv.sqlite serve --access-token localdenoaccesstoken
@@ -235,4 +241,3 @@ services:
 volumes:
   denokv:
     driver: local
-

--- a/app/docker-compose-test.yml
+++ b/app/docker-compose-test.yml
@@ -1,0 +1,38 @@
+services:
+  test:
+    depends_on:
+      api1:
+        condition: service_healthy
+    image: denoland/deno:alpine-2.1.4
+    command: deno test --watch --unsafely-ignore-certificate-errors --allow-all --unstable-broadcast-channel --unstable-kv .
+    working_dir: /app/test
+    extra_hosts:
+      - host.docker.internal:host-gateway
+      - minio.worker-metaframe.localhost:host-gateway
+      - worker-metaframe.localhost:host-gateway
+      - worker-metaframe-api2.dev:host-gateway
+    environment:
+      # APP_PORT is only needed for the upload/curl/dns/docker fiasco
+      - APP_PORT=${APP_PORT:-443}
+      - IGNORE_CERTIFICATE_ERRORS=true
+      - NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-}
+      - API_URL=http://api1:8081
+      - DENO_DIR=/deno
+      - DENO_INSTALL_ROOT=/deno
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-minioaccesskey123123}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-minioaccesskey123123}
+      - AWS_REGION=${AWS_REGION:-us-west-2}
+      - AWS_ENDPOINT=${AWS_ENDPOINT:-https://minio.worker-metaframe.localhost}:${APP_PORT:-443}
+      - AWS_S3_BUCKET=${AWS_S3_BUCKET:-localbucket}
+      - DENO_KV_ACCESS_TOKEN=localdenoaccesstoken
+      - DENO_KV_URL=http://denokv:4512
+      - REDIS_URL=redis://redis:6379
+    volumes:
+      - deno:/deno
+      - .:/app
+    labels:
+      - "custom.label=worker-metaframe.localhost"
+    networks:
+      - default
+    logging:
+      driver: ${LOGGING_TESTS:-json-file}

--- a/app/docker-compose.yml
+++ b/app/docker-compose.yml
@@ -23,9 +23,12 @@ services:
     restart: always
     volumes:
       - .cache/minio:/data
+    networks:
+      - default
     labels:
       - "custom.label=worker-metaframe.localhost"
       - "traefik.enable=true"
+      # - "traefik.http.routers.minio.rule=Host(`minio.worker-metaframe.localhost`) || Host(`minio.worker-metaframe.localhost`)"
       - "traefik.http.routers.minio.rule=Host(`minio.worker-metaframe.localhost`)"
       - "traefik.http.routers.minio.entrypoints=websecure"
       # Apply the CORS middleware to the router
@@ -70,11 +73,15 @@ services:
       - .cache/traefik/certs:/etc/certs:ro
       - .traefik/config.yml:/etc/traefik/config.yml
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - default
 
   redis:
     image: redis:7.2.4
     healthcheck:
       test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+    networks:
+      - default
 
 networks:
   default:

--- a/app/justfile
+++ b/app/justfile
@@ -73,11 +73,11 @@ green := "\\e[32m"
     deno fmt {{ args }}
     find . -name justfile -exec just --fmt --unstable -f {} {{ args }} \;
 
-status queue="local1":
-    curl https://{{ APP_FQDN }}:{{ APP_PORT }}/{{ queue }}/status | jq .
+status-dev:
+    curl https://{{ APP_FQDN }}:{{ APP_PORT }}/local1/status | jq .
 
-status-test queue="local1":
-    APP_PORT=4470 curl https://{{ APP_FQDN }}:4470/{{ queue }}/status | jq .
+status-test port:
+    curl https://{{ APP_FQDN }}:{{ port }}/local1/status | jq .
 
 status-prod queue="public1":
     curl https://container.mtfm.io/{{ queue }}/status | jq .
@@ -87,7 +87,8 @@ test: check
     set -e # exit when any command fails, preserving the status of the failed command
 
     cleanup() {
-        docker compose --project-name=test -f docker-compose.yml -f docker-compose-remote.yml down 2>/dev/null || true
+        echo "Cleaning up test stack..."
+        docker compose --project-name=test -f docker-compose.yml -f docker-compose-remote.yml -f docker-compose-test.yml down 2>/dev/null || true
     }
 
     trap cleanup EXIT # cleanup when the script exits for any reason, including failure
@@ -132,8 +133,9 @@ test: check
     # This is causing currently unknown issues, a dangling worker 
     docker rm test-worker-1 2>/dev/null || true
     docker compose --project-name=test -f docker-compose.yml -f docker-compose-remote.yml up --build --remove-orphans --detach
+    # functional tests
+    just test/test-in-docker
     just worker/test
-    just test/test
     just shared/test
     just cli/test
 
@@ -150,7 +152,7 @@ _mkcert: _ensure_mkcert
     #!/usr/bin/env bash
     rm -rf .cache/traefik/certs
     mkdir -p .cache/traefik/certs/ ;
-    mkcert -cert-file .cache/traefik/certs/local-cert.pem -key-file .cache/traefik/certs/local-key.pem {{ APP_FQDN }} minio.{{ APP_FQDN }} localhost ;
+    mkcert -cert-file .cache/traefik/certs/local-cert.pem -key-file .cache/traefik/certs/local-key.pem {{ APP_FQDN }} minio.{{ APP_FQDN }} worker-metaframe.localhost worker-metaframe-api2.dev minio.worker-metaframe.localhost localhost ;
     if grep -q "{{ APP_FQDN }}" /etc/hosts; then
         echo -e "✅ Hostname {{ APP_FQDN }} found in /etc/hosts"
     else

--- a/app/shared/src/shared/dataref_test.ts
+++ b/app/shared/src/shared/dataref_test.ts
@@ -3,6 +3,6 @@ import { assertExists } from "https://deno.land/std@0.224.0/assert/mod.ts";
 import { convertJobOutputDataRefsToExpectedFormat } from "./dataref.ts";
 
 Deno.test("test something", () => {
-  console.log("test something", convertJobOutputDataRefsToExpectedFormat);
+  // console.log("test something", convertJobOutputDataRefsToExpectedFormat);
   assertExists(convertJobOutputDataRefsToExpectedFormat);
 });

--- a/app/test/functional.ts
+++ b/app/test/functional.ts
@@ -1,1 +1,0 @@
-export const FOO = "bar";

--- a/app/test/justfile
+++ b/app/test/justfile
@@ -2,22 +2,26 @@ set shell := ["bash", "-c"]
 set dotenv-load := true
 set export := true
 
-normal := '\033[0m'
-green := "\\e[32m"
 APP_PORT := env_var_or_default("APP_PORT", "443")
 API_URL := "https://worker-metaframe.localhost:" + APP_PORT
+normal := '\033[0m'
+green := "\\e[32m"
 
 @_help:
     just --list --unsorted --list-heading $'Testing commands:\n'
 
 # Quick type check
 @check:
-    deno check functional_test.ts
+    deno check src
     echo "✅ tests compilation"
 
 @watch:
-    deno test --unsafely-ignore-certificate-errors --watch --allow-all --unstable-broadcast-channel --unstable-kv .
+    deno test --unsafely-ignore-certificate-errors --watch --allow-all --unstable-broadcast-channel --unstable-kv src
 
 @test:
-    deno test --unsafely-ignore-certificate-errors --allow-all --unstable-broadcast-channel --unstable-kv .
+    deno test --unsafely-ignore-certificate-errors --allow-all --unstable-broadcast-channel --unstable-kv src
     echo "✅ functional tests"
+
+@test-in-docker stack="test":
+    cd .. && \
+    APP_PORT={{ APP_PORT }} docker compose --project-name={{ stack }} -f docker-compose.yml -f docker-compose-remote.yml -f docker-compose-test.yml run --no-deps --rm test deno test --unsafely-ignore-certificate-errors --allow-all src

--- a/app/test/src/functional_test.ts
+++ b/app/test/src/functional_test.ts
@@ -9,11 +9,10 @@ import {
   StateChangeValueFinished,
   WebsocketMessageServerBroadcast,
   WebsocketMessageTypeServerBroadcast,
-} from "../shared/src/mod.ts";
-import { createNewContainerJobMessage } from "../shared/src/shared/jobtools.ts";
+} from "../../shared/src/mod.ts";
+import { createNewContainerJobMessage } from "../../shared/src/shared/jobtools.ts";
 
 const API_URL = Deno.env.get("API_URL") || "http://api1:8081";
-// console.log('API_URL', API_URL);
 
 Deno.test(
   "pretend to be a client: submit job and get expected results",
@@ -21,6 +20,14 @@ Deno.test(
     const socket = new WebSocket(
       `${API_URL.replace("http", "ws")}/local1/client`,
     );
+
+    // https://github.com/metapages/compute-queues/issues/124
+    await createNewContainerJobMessage({
+      definition: {
+        image: "alpine:3.18.5",
+        command: "sleep 3",
+      },
+    });
 
     const definition = {
       image: "alpine:3.18.5",
@@ -36,6 +43,7 @@ Deno.test(
       reject,
     } = Promise.withResolvers<string>();
 
+    let jobSuccessfullySubmitted = false;
     socket.onmessage = (message: MessageEvent) => {
       const messageString = message.data.toString();
       const possibleMessage: WebsocketMessageServerBroadcast = JSON.parse(
@@ -52,10 +60,11 @@ Deno.test(
           if (!jobState) {
             break;
           }
+          jobSuccessfullySubmitted = true;
           if (jobState.state === DockerJobState.Finished) {
             const finishedState = jobState.value as StateChangeValueFinished;
-            const lines: string = finishedState.result?.logs?.map((l) =>
-              l[0]
+            const lines: string = finishedState.result?.logs?.map(
+              (l) => l[0],
             )[0]!;
             resolve(lines);
           }
@@ -65,12 +74,21 @@ Deno.test(
       }
     };
 
-    console.log(`opening the socket to the API server...`);
+    // console.log(`opening the socket to the API server...`);
     await open(socket);
     // console.log(`...socket opened. Sending message...`, message);
-    socket.send(JSON.stringify(message));
 
-    console.log(`...awaiting job to finish`);
+    // Workaround for https://github.com/metapages/compute-queues/issues/124
+    // Job submisison should confirm the job is submitted.
+    // Browser clients kinda do this already by resubmitting if the job is
+    // not on the results.
+    while (!jobSuccessfullySubmitted) {
+      // console.log(`...submitting job...`);
+      socket.send(JSON.stringify(message));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    // console.log(`...awaiting job to finish`);
     const result = await jobCompleteDeferred;
     assertEquals(
       result,
@@ -82,86 +100,85 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "submit multiple jobs and get expected results",
-  async () => {
-    const socket = new WebSocket(
-      `${API_URL.replace("http", "ws")}/local1/client`,
-    );
-    const count = 3;
-    const definitions = Array.from(Array(count).keys()).map((i) => ({
-      image: "alpine:3.18.5",
-      command: `echo ${Math.random()}`,
-    }));
+Deno.test("submit multiple jobs and get expected results", async () => {
+  const socket = new WebSocket(
+    `${API_URL.replace("http", "ws")}/local1/client`,
+  );
+  const count = 3;
+  const definitions = Array.from(Array(count).keys()).map((i) => ({
+    image: "alpine:3.18.5",
+    command: `echo ${Math.random()}`,
+  }));
 
-    const jobIds = new Set<string>();
-    const jobIdsFinished = new Set<string>();
+  const jobIds = new Set<string>();
+  const jobIdsFinished = new Set<string>();
 
-    const messages = await Promise.all(definitions.map(async (definition) => {
+  const messages = await Promise.all(
+    definitions.map(async (definition) => {
       const message = await createNewContainerJobMessage({
         definition,
       });
       jobIds.add(message.jobId);
       return message;
-    }));
+    }),
+  );
 
-    const promises = messages.map((_) => (Promise.withResolvers<string>()));
+  const promises = messages.map((_) => Promise.withResolvers<string>());
 
-    socket.onmessage = (message: MessageEvent) => {
-      const messageString = message.data.toString();
-      const possibleMessage: WebsocketMessageServerBroadcast = JSON.parse(
-        messageString,
-      );
-      switch (possibleMessage.type) {
-        case WebsocketMessageTypeServerBroadcast.JobStates:
-        case WebsocketMessageTypeServerBroadcast.JobStateUpdates:
-          const someJobsPayload = possibleMessage.payload as BroadcastJobStates;
-          if (!someJobsPayload) {
-            break;
-          }
-          jobIds.forEach((jobId) => {
-            const jobState = someJobsPayload.state.jobs[jobId];
-            if (!jobState) {
-              return;
-            }
-            if (jobState.state === DockerJobState.Finished) {
-              const finishedState = jobState.value as StateChangeValueFinished;
-              const lines: string = finishedState.result?.logs?.map((l) =>
-                l[0]
-              )[0]!;
-              const i = messages.findIndex((m) => m.jobId === jobId);
-              if (i >= 0 && lines && !jobIdsFinished.has(jobId)) {
-                promises[i]?.resolve(lines.trim());
-                console.log(
-                  `🐸 [test] 📡 job ${jobId} finished ${jobIdsFinished.size} / ${count}`,
-                );
-                jobIdsFinished.add(jobId);
-              }
-            }
-          });
+  socket.onmessage = (message: MessageEvent) => {
+    const messageString = message.data.toString();
+    const possibleMessage: WebsocketMessageServerBroadcast = JSON.parse(
+      messageString,
+    );
+    switch (possibleMessage.type) {
+      case WebsocketMessageTypeServerBroadcast.JobStates:
+      case WebsocketMessageTypeServerBroadcast.JobStateUpdates:
+        const someJobsPayload = possibleMessage.payload as BroadcastJobStates;
+        if (!someJobsPayload) {
           break;
-        default:
-          //ignored
-      }
-    };
-
-    // console.log(`opening the socket to the API server...`)
-    await open(socket);
-    // console.log(`...socket opened. Sending messages...`);
-    for (const { message } of messages) {
-      socket.send(JSON.stringify(message));
+        }
+        jobIds.forEach((jobId) => {
+          const jobState = someJobsPayload.state.jobs[jobId];
+          if (!jobState) {
+            return;
+          }
+          if (jobState.state === DockerJobState.Finished) {
+            const finishedState = jobState.value as StateChangeValueFinished;
+            const lines: string = finishedState.result?.logs?.map(
+              (l) => l[0],
+            )[0]!;
+            const i = messages.findIndex((m) => m.jobId === jobId);
+            if (i >= 0 && lines && !jobIdsFinished.has(jobId)) {
+              promises[i]?.resolve(lines.trim());
+              // console.log(
+              //   `🐸 [test] 📡 job ${jobId} finished ${jobIdsFinished.size} / ${count}`,
+              // );
+              jobIdsFinished.add(jobId);
+            }
+          }
+        });
+        break;
+      default:
+        //ignored
     }
+  };
 
-    // console.log(`...awaiting jobs to finish`);
-    const results = await Promise.all(promises.map((p) => p.promise));
-    results.forEach((result, i: number) => {
-      assertEquals(result, definitions[i].command.replace("echo ", ""));
-    });
+  // console.log(`opening the socket to the API server...`)
+  await open(socket);
+  // console.log(`...socket opened. Sending messages...`);
+  for (const { message } of messages) {
+    socket.send(JSON.stringify(message));
+  }
 
-    socket.close();
-    await closed(socket);
-  },
-);
+  // console.log(`...awaiting jobs to finish`);
+  const results = await Promise.all(promises.map((p) => p.promise));
+  results.forEach((result, i: number) => {
+    assertEquals(result, definitions[i].command.replace("echo ", ""));
+  });
+
+  socket.close();
+  await closed(socket);
+});
 
 Deno.test(
   "submit multiple jobs from the same client source: older jobs are killed",
@@ -172,21 +189,27 @@ Deno.test(
     const count = 3;
     const definitions = Array.from(Array(count).keys()).map((i) => ({
       image: "alpine:3.18.5",
-      command: `sh -c "echo ${Math.random()}; sleep 3"`,
+      // The earlier jobs can run for ages since they will actually be killed,
+      // while the last job will replace them so can finished quickly.
+      command: `sh -c "echo ${Math.random()}; sleep ${
+        i + 1 < count ? "10" : "1"
+      }"`,
     }));
 
     const source = `test-${Math.random()}`;
     const jobIdsSubmissionOrder: string[] = [];
     const jobIdsFinishReason = new Map<string, string>();
 
-    const messages = await Promise.all(definitions.map(async (definition) => {
-      const message = await createNewContainerJobMessage({
-        definition,
-        source,
-      });
-      jobIdsSubmissionOrder.push(message.jobId);
-      return message;
-    }));
+    const messages = await Promise.all(
+      definitions.map(async (definition) => {
+        const message = await createNewContainerJobMessage({
+          definition,
+          source,
+        });
+        jobIdsSubmissionOrder.push(message.jobId);
+        return message;
+      }),
+    );
 
     const promiseEnd = Promise.withResolvers<string>();
 
@@ -227,7 +250,7 @@ Deno.test(
     await open(socket);
     for (const { message } of messages) {
       // create a delay to simulate a slow client
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1500));
       socket.send(JSON.stringify(message));
     }
 

--- a/app/test/src/storage_test.ts
+++ b/app/test/src/storage_test.ts
@@ -1,0 +1,194 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import { closed, open } from "@korkje/wsi";
+
+import {
+  BroadcastJobStates,
+  dataRefToBuffer,
+  DockerJobDefinitionInputRefs,
+  DockerJobState,
+  StateChangeValueFinished,
+  WebsocketMessageServerBroadcast,
+  WebsocketMessageTypeServerBroadcast,
+} from "../../shared/src/mod.ts";
+import {
+  createNewContainerJobMessage,
+  fileToDataref,
+} from "../../shared/src/shared/jobtools.ts";
+
+const API_URL = Deno.env.get("API_URL") || "http://api1:8081";
+
+Deno.test(
+  "Run a job that uploads input files and validates the input",
+  async () => {
+    const socket = new WebSocket(
+      `${API_URL.replace("http", "ws")}/local1/client`,
+    );
+
+    const word = `hello${Math.floor(Math.random() * 10000)}`;
+    const content = `${Array(50).fill(word).join("")}`;
+    const rootName = `hello${Math.floor(Math.random() * 10000)}.txt`;
+    const fileName = `/tmp/${rootName}`;
+
+    await Deno.writeTextFile(fileName, content);
+
+    // Install curl in case it's not available
+    // Check if curl is installed first
+    // Because curl is needed for uploading files (for now)
+    // This could be put somewhere else but this is currently the
+    // only test that needs curl (because of the upload/curl/dns/docker fiasco)
+    const checkCurl = new Deno.Command("which", {
+      args: ["curl"],
+    });
+    const checkResult = await checkCurl.output();
+
+    if (!checkResult.success) {
+      const command = new Deno.Command("apk", {
+        args: ["add", "curl"],
+      });
+      const { success, stdout, stderr } = await command.output();
+      if (!success) {
+        throw new Error(
+          `Failed to install curl: ${new TextDecoder().decode(stderr)}`,
+        );
+      }
+    }
+
+    const dataref = await fileToDataref(fileName, API_URL);
+
+    const definition: DockerJobDefinitionInputRefs = {
+      image: "alpine:3.18.5",
+      command: `sh -c 'cp /inputs/${rootName} /outputs/${rootName}'`,
+      inputs: {
+        [rootName]: dataref,
+      },
+    };
+    const { message, jobId } = await createNewContainerJobMessage({
+      definition,
+    });
+
+    let {
+      promise: jobCompleteDeferred,
+      resolve,
+      reject,
+    } = Promise.withResolvers<void>();
+
+    socket.onmessage = async (message: MessageEvent) => {
+      const messageString = message.data.toString();
+      const possibleMessage: WebsocketMessageServerBroadcast = JSON.parse(
+        messageString,
+      );
+      switch (possibleMessage.type) {
+        case WebsocketMessageTypeServerBroadcast.JobStates:
+        case WebsocketMessageTypeServerBroadcast.JobStateUpdates:
+          const someJobsPayload = possibleMessage.payload as BroadcastJobStates;
+          if (!someJobsPayload) {
+            break;
+          }
+          const jobState = someJobsPayload.state.jobs[jobId];
+          if (!jobState) {
+            break;
+          }
+          if (jobState.state === DockerJobState.Finished) {
+            const finishedState = jobState.value as StateChangeValueFinished;
+            const outputs = finishedState.result?.outputs;
+            const dataref = outputs?.[rootName];
+            assert(!!dataref);
+            assertEquals(finishedState?.reason, "Success");
+            assertEquals(finishedState?.result?.error, undefined);
+            const buffer = await dataRefToBuffer(dataref, API_URL);
+            const contentFromJob = new TextDecoder().decode(buffer);
+            assertEquals(content, contentFromJob.trim());
+            resolve();
+          }
+          break;
+        default:
+          //ignored
+      }
+    };
+
+    // console.log(`opening the socket to the API server...`);
+    await open(socket);
+    // console.log(`...socket opened. Sending message...`, message);
+    socket.send(JSON.stringify(message));
+
+    // console.log(`...awaiting job to finish`);
+    const result = await jobCompleteDeferred;
+
+    socket.close();
+    await closed(socket);
+  },
+);
+
+Deno.test(
+  "Run a job that creates output files, downloads and checks the file",
+  async () => {
+    const socket = new WebSocket(
+      `${API_URL.replace("http", "ws")}/local1/client`,
+    );
+
+    const word = `hello${Math.floor(Math.random() * 10000)}`;
+    const content = `${Array(50).fill(word).join("")}`;
+    const definition = {
+      image: "alpine:3.18.5",
+      command: `sh -c 'echo ${content} > /outputs/hello.txt'`,
+    };
+    const { message, jobId } = await createNewContainerJobMessage({
+      definition,
+    });
+
+    let {
+      promise: jobCompleteDeferred,
+      resolve,
+      reject,
+    } = Promise.withResolvers<void>();
+
+    socket.onmessage = async (message: MessageEvent) => {
+      const messageString = message.data.toString();
+      const possibleMessage: WebsocketMessageServerBroadcast = JSON.parse(
+        messageString,
+      );
+      switch (possibleMessage.type) {
+        case WebsocketMessageTypeServerBroadcast.JobStates:
+        case WebsocketMessageTypeServerBroadcast.JobStateUpdates:
+          const someJobsPayload = possibleMessage.payload as BroadcastJobStates;
+          if (!someJobsPayload) {
+            break;
+          }
+          const jobState = someJobsPayload.state.jobs[jobId];
+          if (!jobState) {
+            break;
+          }
+          if (jobState.state === DockerJobState.Finished) {
+            const finishedState = jobState.value as StateChangeValueFinished;
+            const outputs = finishedState.result?.outputs;
+            const dataref = outputs?.["hello.txt"];
+            assert(!!dataref);
+            assertEquals(finishedState?.reason, "Success");
+            assertEquals(finishedState?.result?.error, undefined);
+            const buffer = await dataRefToBuffer(dataref, API_URL);
+            const contentFromJob = new TextDecoder().decode(buffer);
+            assertEquals(content, contentFromJob.trim());
+            resolve();
+          }
+          break;
+        default:
+          //ignored
+      }
+    };
+
+    // console.log(`opening the socket to the API server...`);
+    await open(socket);
+    // console.log(`...socket opened. Sending message...`, message);
+    socket.send(JSON.stringify(message));
+
+    // console.log(`...awaiting job to finish`);
+    const result = await jobCompleteDeferred;
+
+    socket.close();
+    await closed(socket);
+  },
+);

--- a/app/worker/Dockerfile
+++ b/app/worker/Dockerfile
@@ -1,7 +1,7 @@
 #################################################################
 # Base image
 #################################################################
-FROM denoland/deno:2.0.3 AS worker
+FROM denoland/deno:2.1.4 AS worker
 
 ENV DOCKER_VERSION=5:27.1.1-1~debian.12~bookworm
 

--- a/app/worker/src/docker/client.ts
+++ b/app/worker/src/docker/client.ts
@@ -15,7 +15,7 @@ export const createDockerClient = (port = 3000) => {
     // Listen on TCP port 3000
     tcpListener = Deno.listen({ port });
 
-    console.log(`Listening on TCP port ${port}`);
+    // console.log(`Listening on TCP port ${port}`);
 
     for await (const tcpConn of tcpListener) {
       handleConnection(tcpConn);
@@ -66,7 +66,7 @@ export const createDockerClient = (port = 3000) => {
   // const docker = new Docker({socketPath: "/var/run/docker.sock"});
   const docker = new Docker({ protocol: "http", host: "localhost", port });
   const close = () => {
-    console.log("tcpListener", tcpListener);
+    // console.log("tcpListener", tcpListener);
     closed = true;
     tcpListener?.close();
     unixConn?.close();

--- a/app/worker/src/docker/client_test.ts
+++ b/app/worker/src/docker/client_test.ts
@@ -13,11 +13,11 @@ Deno.test("test docker building", async () => {
         stream,
         (err: any, res: any) => err ? reject(err) : resolve(res),
         (progressEvent: Event) => {
-          console.log(progressEvent);
+          // console.log(progressEvent);
         },
       );
     });
-    console.log("Built image");
+    // console.log("Built image");
   } catch (error) {
     console.error("Error building image:", error);
     close();

--- a/app/worker/src/queue/DockerJob.ts
+++ b/app/worker/src/queue/DockerJob.ts
@@ -195,12 +195,6 @@ export const dockerJobExecute = async (
     grabberErrStream.pipe(errStream!);
   }
 
-  const runningContainers: any[] = await docker.listContainers({
-    Labels: {
-      "container.mtfm.io/id": args.id,
-    },
-  });
-
   const finish = async () => {
     try {
       createOptions.image = await ensureDockerImage({
@@ -241,7 +235,7 @@ export const dockerJobExecute = async (
       container = docker.getContainer(existingJobContainer.Id);
     }
 
-    console.log("🚀 createOptions", createOptions);
+    // console.log("🚀 createOptions", createOptions);
 
     if (!container) {
       container = await docker.createContainer(createOptions);

--- a/app/worker/src/queue/dockerImage.ts
+++ b/app/worker/src/queue/dockerImage.ts
@@ -58,7 +58,7 @@ export const ensureDockerImage = async (args: {
   build?: DockerJobImageBuild;
   sender: WebsocketMessageSenderWorker;
 }): Promise<string> => {
-  console.log("ensureDockerImage", args);
+  // console.log("ensureDockerImage", args);
   let { jobId, image, pullOptions, build, sender } = args;
 
   if (!image && !build) {


### PR DESCRIPTION
Fixes #121
Fixes #119

<api>/upload -> <api>/api/v1/upload
<api>/download -> <api>/api/v1/download

The original endpoints are kept to not break existing workers, the new endpoints simply do a 302 redirect to the S3 URL, instead of the dataref complexity (which breaks downstream).

I also tested this manually with an older worker image, so it's backwards compatible.

Fixed the functional tests also.
