### PR TITLE
missing-commands-in-docs

### DIFF
--- a/app/api/deno.json
+++ b/app/api/deno.json
@@ -14,5 +14,8 @@
     "mutative": "npm:mutative@1.0.11",
     "safe-stable-stringify": "npm:safe-stable-stringify@2.4.3",
     "uuid": "npm:uuid@9.0.1"
+  },
+  "fmt": {
+    "exclude": ["dist", "README.md", "*.json", "*.lock"]
   }
 }

--- a/app/browser/deno.json
+++ b/app/browser/deno.json
@@ -1,0 +1,5 @@
+{
+  "fmt": {
+    "exclude": ["dist", "README.md", "*.json", "*.lock"]
+  }
+}

--- a/app/justfile
+++ b/app/justfile
@@ -19,95 +19,10 @@ green := "\\e[32m"
 @_validate_mode mode="":
     @if [ "{{ mode }}" = "remote" ] || [ "{{ mode }}" = "local" ]; then :; else echo "Error: Mode must be 'remote' or 'local'" >&2; exit 1; fi
 
-# Develop: open the browser and start the dev stack
+# Develop: open the browser and start the dev stack [remote|local]
 @dev mode="remote" +args="": (_validate_mode mode) _ensure-all open (_up mode args)
 
-# Start the docker compose local stack
-@_up mode="remote" +args="": (_validate_mode mode) _ensure-all _mkcert
-    #!/usr/bin/env bash
-    # A local NPM registry saves time, bandwidth, and avoids rate limits
-    # If a local npm registry cache is running, use that for all npm modules (faster and better when internet not great)
-    # docker run -d -v verdaccio_npm_storage:/verdaccio/storage --name verdaccio -p 4873:4873 verdaccio/verdaccio
-    # https://verdaccio.org/docs/docker/
-    STATUS_CODE=$(curl --max-time 2 --write-out '%{http_code}' --silent --output /dev/null http://localhost:4873)
-    if [ $STATUS_CODE = "200" ]; then
-        export NPM_CONFIG_REGISTRY=http://host.docker.internal:4873
-    fi
-    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml rm --force 2>/dev/null || true
-    docker rm dev-worker-1 2>/dev/null || true
-    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml up --remove-orphans {{ args }}
-
-# Shut down the local stack: 'docker compose down'
-@down mode="remote" +args="": (_validate_mode mode)
-    #!/usr/bin/env bash
-    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml down {{ args }}
-
-deploy version="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    # Get version argument or bump current version
-    VERSION={{ version }}
-    if [ "$VERSION" = "" ]; then
-        # Get current version from mod.json
-        CURRENT_VERSION=$(cat worker/mod.json | jq -r '.version')
-        # Split version into components
-        IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-        # Increment patch version
-        PATCH=$((PATCH + 1))
-        # Construct new version
-        VERSION="$MAJOR.$MINOR.$PATCH"
-    fi
-
-    # Update version in mod.json
-    TMP=$(mktemp)
-    jq ".version = \"$VERSION\"" worker/mod.json > "$TMP" && mv "$TMP" worker/mod.json
-
-    echo "chore: bump version to $VERSION"
-    # Commit changes
-    git add worker/mod.json
-    git commit -m "chore: bump version to $VERSION"
-
-# Clean up the project
-@clean mode="remote" +args="": (_validate_mode mode)
-    #!/usr/bin/env bash
-    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml down -v
-    just browser/clean
-    rm -rf .cache
-
-# Open the browser to the local frontend
-@open: _ensure-all
-    deno run --allow-all https://deno.land/x/metapages@v0.0.27/exec/open_url.ts 'https://metapages.github.io/load-page-when-available/?url=https://{{ APP_FQDN }}:{{ APP_PORT }}#?job=JTdCJTIyY29tbWFuZCUyMiUzQSUyMmxzJTIwLWxhJTIyJTJDJTIyaW1hZ2UlMjIlM0ElMjJhbHBpbmUlM0EzLjE4LjUlMjIlN0Q=&queue=local1' || true
-
-# Quick compilation checks
-@check: _ensure-all
-    echo -n "worker check..."
-    just worker/check
-    echo -n "api check..."
-    just api/check
-    echo -n "browser check..."
-    just browser/check
-    echo -n "test check..."
-    just test/check
-    echo -n "shared check..."
-    just shared/check
-    echo -n "cli check..."
-    just cli/check
-
-# Format all supported files
-@fmt +args="":
-    deno fmt {{ args }}
-    find . -name justfile -exec just --fmt --unstable -f {} {{ args }} \;
-
-status-dev:
-    curl https://{{ APP_FQDN }}:{{ APP_PORT }}/local1/status | jq .
-
-status-test port:
-    curl https://{{ APP_FQDN }}:{{ port }}/local1/status | jq .
-
-status-prod queue="public1":
-    curl https://container.mtfm.io/{{ queue }}/status | jq .
-
+# Runs All Functional Tests and checks code
 test: check
     #!/usr/bin/env bash
     set -e # exit when any command fails, preserving the status of the failed command
@@ -165,11 +80,107 @@ test: check
     just shared/test
     just cli/test
 
+# Bump the version, commit, CI will deploy and publish artifacts
+deploy version="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Get version argument or bump current version
+    VERSION={{ version }}
+    if [ "$VERSION" = "" ]; then
+        # Get current version from mod.json
+        CURRENT_VERSION=$(cat worker/mod.json | jq -r '.version')
+        # Split version into components
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+        # Increment patch version
+        PATCH=$((PATCH + 1))
+        # Construct new version
+        VERSION="$MAJOR.$MINOR.$PATCH"
+    fi
+
+    # Update version in mod.json
+    TMP=$(mktemp)
+    jq ".version = \"$VERSION\"" worker/mod.json > "$TMP" && mv "$TMP" worker/mod.json
+
+    echo "chore: bump version to $VERSION"
+    # Commit changes
+    git add worker/mod.json
+    git commit -m "chore: bump version to $VERSION"
+
+# Start the docker compose local stack
+@_up mode="remote" +args="": (_validate_mode mode) _ensure-all _mkcert
+    #!/usr/bin/env bash
+    # A local NPM registry saves time, bandwidth, and avoids rate limits
+    # If a local npm registry cache is running, use that for all npm modules (faster and better when internet not great)
+    # docker run -d -v verdaccio_npm_storage:/verdaccio/storage --name verdaccio -p 4873:4873 verdaccio/verdaccio
+    # https://verdaccio.org/docs/docker/
+    STATUS_CODE=$(curl --max-time 2 --write-out '%{http_code}' --silent --output /dev/null http://localhost:4873)
+    if [ $STATUS_CODE = "200" ]; then
+        export NPM_CONFIG_REGISTRY=http://host.docker.internal:4873
+    fi
+    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml rm --force 2>/dev/null || true
+    docker rm dev-worker-1 2>/dev/null || true
+    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml up --remove-orphans {{ args }}
+
+# Shut down the local stack: 'docker compose down'
+@down mode="remote" +args="": (_validate_mode mode)
+    #!/usr/bin/env bash
+    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml down {{ args }}
+
 # Clean up the project
+@clean mode="remote" +args="": (_validate_mode mode)
+    #!/usr/bin/env bash
+    docker compose --project-name=dev -f docker-compose.yml -f docker-compose-{{ mode }}.yml down -v
+    just browser/clean
+    rm -rf .cache
+
+# Open the browser to the local frontend
+@open: _ensure-all
+    deno run --allow-all https://deno.land/x/metapages@v0.0.27/exec/open_url.ts 'https://metapages.github.io/load-page-when-available/?url=https://{{ APP_FQDN }}:{{ APP_PORT }}#?job=JTdCJTIyY29tbWFuZCUyMiUzQSUyMmxzJTIwLWxhJTIyJTJDJTIyaW1hZ2UlMjIlM0ElMjJhbHBpbmUlM0EzLjE4LjUlMjIlN0Q=&queue=local1' || true
+
+# Quick compilation checks
+@check: _ensure-all
+    echo -n "worker check..."
+    just worker/check
+    echo -n "api check..."
+    just api/check
+    echo -n "browser check..."
+    just browser/check
+    echo -n "test check..."
+    just test/check
+    echo -n "shared check..."
+    just shared/check
+    echo -n "cli check..."
+    just cli/check
+
+# Format all supported files
+@fmt +args="":
+    # deno fmt {{ args }}
+    cd browser && deno fmt {{ args }}
+    cd worker && deno fmt {{ args }}
+    cd api && deno fmt {{ args }}
+    cd test && deno fmt {{ args }}
+    cd cli && deno fmt {{ args }}
+    cd shared && deno fmt {{ args }}
+    find . -name justfile -exec just --fmt --unstable -f {} {{ args }} \;
+
+# Calls the status endpoint of the local dev stack
+status-dev:
+    curl https://{{ APP_FQDN }}:{{ APP_PORT }}/local1/status | jq .
+
+# Calls the status endpoint of the local test stack
+status-test port:
+    curl https://{{ APP_FQDN }}:{{ port }}/local1/status | jq .
+
+# Calls the status endpoint of the production API at a given queue
+status-prod queue="public1":
+    curl https://container.mtfm.io/{{ queue }}/status | jq .
+
+# Clean up the test stack, if it didn't exit cleanly
 @test-cleanup:
     docker compose --project-name=test -f docker-compose.yml -f docker-compose-remote.yml down || true
 
-# Publish e.g. docker images with whatever versioning scheme is appropriate
+# Publish worker docker images with whatever versioning scheme is appropriate
 @publish-versioned-artifacts version="":
     just worker/publish-docker-images {{ version }}
 

--- a/app/worker/deno.json
+++ b/app/worker/deno.json
@@ -10,5 +10,8 @@
     "safe-stable-stringify": "npm:safe-stable-stringify@2.4.3"
   },
   "nodeModulesDir": "none",
-  "unstable": ["sloppy-imports"]
+  "unstable": ["sloppy-imports"],
+  "fmt": {
+    "exclude": ["dist", "README.md", "*.json", "*.lock"]
+  }
 }

--- a/justfile
+++ b/justfile
@@ -33,6 +33,14 @@ cyan := "\\e[36m"
 @dev mode="remote" +args="": (_validate_mode mode)
     just app/dev {{ mode }} {{ args }}
 
+# Runs All Functional Tests and checks code
+@test:
+    just app test
+
+# Bump the version, commit, CI will deploy and publish artifacts
+@deploy version="":
+    just app/deploy {{ version }}
+
 # Shut Down Development Environment
 @down mode="remote" +args="": (_validate_mode mode)
     just app/down {{ mode }} {{ args }}
@@ -80,10 +88,6 @@ run-local-workers: publish-versioned-artifacts
     VERSION=$(cat app/worker/mod.json | jq -r .version)
     docker run --restart unless-stopped -tid -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp metapage/metaframe-docker-worker:$VERSION run --cpus=2 public1
     docker run --restart unless-stopped -tid -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp metapage/metaframe-docker-worker:$VERSION run --cpus=2 ${DIONS_SECRET_QUEUE}
-
-# Checks and tests
-@test:
-    just app test
 
 # Quick compilation checks
 @check:


### PR DESCRIPTION
Fix missing commands in docs, and refactor formatting to consume excludes, otherwise fmt crashes when formatting large dist folders≈Y

