### PR TITLE
171-too-many-files-open

### DIFF
--- a/app/api/src/handlerHono.ts
+++ b/app/api/src/handlerHono.ts
@@ -11,6 +11,7 @@ import { downloadHandler as downloadHandlerDeprecated } from "/@/routes/deprecat
 import { copyJobToQueueHandler } from "/@/routes/api/v1/copy.ts";
 import { submitJobToQueueHandler } from "/@/routes/api/v1/submit.ts";
 import { getJobIdsHandler } from "/@/routes/api/v1/jobIds.ts";
+import { existsHandler } from "/@/routes/api/v1/exists.ts";
 
 const app = new Hono();
 
@@ -35,6 +36,7 @@ app.use("/*", cors() // cors({
 app.get("/healthz", (c: Context) => c.text("OK"));
 
 app.get("/api/v1/download/:key", downloadHandler);
+app.get("/api/v1/exists/:key", existsHandler);
 app.put("/api/v1/upload/:key", uploadHandler);
 app.post("/api/v1/copy", copyJobToQueueHandler);
 app.post("/:queue/job", submitJobToQueueHandler);

--- a/app/api/src/routes/api/v1/exists.ts
+++ b/app/api/src/routes/api/v1/exists.ts
@@ -1,0 +1,24 @@
+import { bucketParams, s3Client } from "/@/routes/s3config.ts";
+import { HeadObjectCommand } from "aws-sdk/client-s3";
+import type { Context } from "hono";
+
+export const existsHandler = async (c: Context) => {
+  const key: string | undefined = c.req.param("key");
+  if (!key) {
+    c.status(400);
+    return c.text("Missing key");
+  }
+
+  try {
+    const command = new HeadObjectCommand({ ...bucketParams, Key: key });
+    await s3Client.send(command);
+    return c.json({ exists: true });
+  } catch (err: unknown) {
+    if ((err as { name: string }).name === "NotFound") {
+      c.status(404);
+      return c.json({ exists: false });
+    }
+    console.error("Error checking file:", err);
+    return c.text((err as Error).message, 500);
+  }
+};

--- a/app/justfile
+++ b/app/justfile
@@ -153,6 +153,7 @@ _up mode="remote" +args="": (_validate_mode mode) _ensure-all _mkcert
     docker rm dev-worker-1 2>/dev/null || true
     docker compose --project-name=dev -f ../docker-compose.yml -f ../docker-compose-{{ mode }}.yml up --remove-orphans {{ args }}
 
+# Watch the local dev stack, running the tests when files change
 @watch mode="remote" +args="": _build_shared
     docker compose --project-name=dev -f ../docker-compose.yml -f ../docker-compose-{{ mode }}.yml -f ../docker-compose-test-{{ mode }}.yml up --remove-orphans {{ args }}
 

--- a/app/shared/src/shared/jobtools.ts
+++ b/app/shared/src/shared/jobtools.ts
@@ -1,6 +1,5 @@
 import { crypto } from "@std/crypto";
 import { encodeHex } from "@std/encoding";
-import { LRUCache } from "lru-cache";
 import { retryAsync } from "retry";
 import { ensureDir, exists } from "std/fs";
 import { dirname } from "std/path";
@@ -27,11 +26,6 @@ import { sanitizeFilename, shaDockerJob } from "/@/shared/util.ts";
 
 const IGNORE_CERTIFICATE_ERRORS: boolean =
   Deno.env.get("IGNORE_CERTIFICATE_ERRORS") === "true";
-
-const FileHashesUploaded = new LRUCache<string, boolean>({
-  max: 10000,
-  ttl: 1000 * 60 * 60 * 24 * 6, // 6 days, less than the time (one week) that the server will keep the file
-});
 
 /**
  * If two workers claim a job, this function will resolve which worker should take the job.
@@ -129,13 +123,17 @@ export const fileToDataref = async (
   const hash = await hashFileOnDisk(file);
 
   if (size > ENV_VAR_DATA_ITEM_LENGTH_MAX) {
-    if (FileHashesUploaded.has(hash)) {
+    const existsUrl = `${address}/api/v1/exists/${hash}`;
+    const existsResponse = await fetch(existsUrl);
+    if (existsResponse.status === 200) {
+      existsResponse.body?.cancel();
       const existsRef: DataRef = {
         value: hash,
         type: DataRefType.key,
       };
       return existsRef;
     }
+    existsResponse.body?.cancel();
 
     const uploadUrl = `${address}/api/v1/upload/${hash}`;
 
@@ -168,7 +166,6 @@ export const fileToDataref = async (
       },
       { delay: 2000, maxTry: 20 },
     );
-    FileHashesUploaded.set(hash, true);
 
     const actualAddress = Deno.env.get("DEV_ONLY_EXTERNAL_SERVER_ADDRESS") ||
       address;
@@ -180,7 +177,7 @@ export const fileToDataref = async (
     return dataRef;
   } else {
     const fileBuffer: Uint8Array = await Deno.readFile(file);
-    const ref: DataRef = await bufferToBase64Ref(fileBuffer);
+    const ref: DataRef = bufferToBase64Ref(fileBuffer);
     return ref;
   }
 };
@@ -287,11 +284,12 @@ export const dataRefToFile = async (
         let count = 0;
         await retryAsync(
           async () => {
+            let file: Deno.FsFile | null = null;
             try {
               const fileResponse = await fetch(url, { redirect: "follow" });
 
               if (fileResponse.ok && fileResponse.body) {
-                const file = await Deno.open(filename, {
+                file = await Deno.open(filename, {
                   write: true,
                   create: true,
                   mode: 0o644,
@@ -303,6 +301,15 @@ export const dataRefToFile = async (
               throw new Error(
                 `Failed attempt ${count} to download ${url}: ${error}`,
               );
+            } finally {
+              if (file) {
+                try {
+                  // https://github.com/denoland/deno/issues/14210
+                  file.close();
+                } catch (_) {
+                  // pass
+                }
+              }
             }
           },
           { delay: 1000, maxTry: 5 },
@@ -374,5 +381,11 @@ export const hashFileOnDisk: (filePath: string) => Promise<string> = async (
   const readableStream = file.readable;
   const fileHashBuffer = await crypto.subtle.digest("SHA-256", readableStream);
   const fileHash = encodeHex(fileHashBuffer);
+  try {
+    // https://github.com/denoland/deno/issues/14210
+    file.close();
+  } catch (_) {
+    // pass
+  }
   return fileHash;
 };

--- a/app/worker/src/queue/dockerClient.ts
+++ b/app/worker/src/queue/dockerClient.ts
@@ -1,14 +1,17 @@
 import { createDockerClient } from "/@/docker/client.ts";
 
+const { docker: dockerClient, close } = createDockerClient(8343);
+
 Deno.addSignalListener("SIGUSR1", () => {
   console.log("GOT SIGUSR1");
+  close();
 });
 
 Deno.addSignalListener("SIGTERM", () => {
   console.log("GOT SIGTERM");
+  close();
 });
 
-const { docker: dockerClient, close } = createDockerClient(8343);
 // Close all docker connections on exit
 globalThis.addEventListener("unload", () => {
   console.log("🔁💥🔁 unload event");

--- a/deno.json
+++ b/deno.json
@@ -29,7 +29,6 @@
     "hono/middleware": "https://deno.land/x/hono@v4.1.0-rc.1/middleware.ts",
     "hono/middleware/cors": "https://deno.land/x/hono@v4.1.0-rc.1/middleware/cors/index.ts",
     "klaw": "npm:klaw@4.1.0",
-    "lru-cache": "npm:lru-cache@11.0.1",
     "metapages/worker/routing/handlerDeno": "https://deno.land/x/metapages@v0.0.27/worker/routing/handlerDeno.ts",
     "ms": "https://deno.land/x/ms@v0.1.0/ms.ts",
     "mutative": "npm:mutative@1.0.11",

--- a/deno.lock
+++ b/deno.lock
@@ -40,7 +40,6 @@
     "npm:fast-deep-equal@*": "3.1.3",
     "npm:fetch-retry@5.0.6": "5.0.6",
     "npm:klaw@4.1.0": "4.1.0",
-    "npm:lru-cache@11.0.1": "11.0.1",
     "npm:mutative@1.0.11": "1.0.11",
     "npm:nanoevents@9.0.0": "9.0.0",
     "npm:object-hash@3.0.0": "3.0.0",
@@ -5631,9 +5630,6 @@
     "long@5.2.4": {
       "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg=="
     },
-    "lru-cache@11.0.1": {
-      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ=="
-    },
     "mkdirp-classic@0.5.3": {
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
@@ -6417,7 +6413,6 @@
       "npm:fast-deep-equal@*",
       "npm:fetch-retry@5.0.6",
       "npm:klaw@4.1.0",
-      "npm:lru-cache@11.0.1",
       "npm:mutative@1.0.11",
       "npm:nanoevents@9.0.0",
       "npm:object-hash@3.0.0",

--- a/justfile
+++ b/justfile
@@ -39,6 +39,10 @@ cyan := "\\e[36m"
 @test mode="remote":
     just app test {{ mode }}
 
+# Watch the local dev stack, running the tests when files change
+@watch mode="remote" +args="":
+    just app watch {{ mode }} {{ args }}
+
 # Bump the version, commit, CI will deploy and publish artifacts
 @deploy version="":
     just app/deploy {{ version }}


### PR DESCRIPTION
Fixes #171

 - adds `/api/v1/exists/<hash>` route to avoid a local cache that attempted to remember uploads
 - various bits to remove resource handles